### PR TITLE
Add script 'proof' to scan logs and buckets for proof debugging data.

### DIFF
--- a/ci/snapshot/Makefile
+++ b/ci/snapshot/Makefile
@@ -14,6 +14,7 @@ ALL_PYTHON = $(wildcard \
 		snapshot-propose \
 		snapshot-update \
 		snapshot-variable \
+		proof \
 		)
 
 SNAPSHOT_PYTHON = $(filter-out cbmc_ci_%.py, $(ALL_PYTHON))

--- a/ci/snapshot/proof
+++ b/ci/snapshot/proof
@@ -180,6 +180,7 @@ class LogGroups:
             print(" .", end='', flush=True)
         print(" done (found {} items)".format(len(log_items)))
         logging.debug("LogGroups filter log events results: %s", log_items)
+        log_items = sorted(log_items, key=lambda item: item['timestamp'])
 
         log_streams = list({event['logStreamName'] for event in log_items})
         logging.info("Returning log group: %s", log_group)
@@ -207,13 +208,20 @@ class PrepareLog:
         if isinstance(proofs, list):
             pattern = ' '.join(['?"{}"'.format(proof) for proof in proofs])
 
-        log_group, log_streams, _ = log_groups.matching_streams(
+        log_group, log_streams, log_results = log_groups.matching_streams(
             log_groups.prepare(), pattern, start, end,
             'Scanning CBMC invocation logs')
-        assert len(log_streams) == 1
+        if len(log_streams) != 1:
+            message = {'UserWarning':
+                       ['Expected to find a single log stream.',
+                        'Log group: {}'.format(log_group),
+                        'Log streams: {}'.format(log_streams)]}
+            print(json.dumps(message, indent=2))
+            raise UserWarning('Expected a single log stream')
 
         self.log_group = log_group
         self.log_stream = log_streams[0]
+        self.log_results = log_results
 
         log_json = log_groups.read_stream(self.log_group, self.log_stream)
         self.repository = prepare_repository(log_json)
@@ -290,13 +298,24 @@ class InvokeLog:
         if isinstance(commits, list):
             pattern = ' '.join(['?"{}"'.format(commit) for commit in commits])
             commit_list = commits
-        log_group, log_streams, _ = log_groups.matching_streams(
+        log_group, log_streams, log_results = log_groups.matching_streams(
             log_groups.invoke(), pattern, start, end,
             'Scanning CI invocation logs')
-        assert len(log_streams) == 1
+
+        if len(log_streams) != 1:
+            message = {'UserWarning':
+                       ['Expected to find a single log stream.',
+                        'Log group: {}'.format(log_group),
+                        'Log streams: {}'.format(log_streams),
+                        'Commits: {}'.format(commits),
+                        'Start: {}'.format(start),
+                        'End: {}'.format(end)]}
+            print(json.dumps(message, indent=2))
+            raise UserWarning('Expected a single log stream')
 
         self.log_group = log_group
         self.log_stream = log_streams[0]
+        self.log_results = log_results
 
         # Webhook payload is the json blog in the log line following
         # "GitHub event:"
@@ -386,11 +405,15 @@ class StatusLog:
     """Manage the logs for the Batch Status lambda function."""
 
     def __init__(self, log_groups, start, end=None):
-        self.errors = []
-        self.log_group, self.log_streams, events = log_groups.matching_streams(
+        log_group, log_streams, log_results = log_groups.matching_streams(
             log_groups.status(), '"Unexpected Verification Result"',
             start, end, 'Scanning proof status logs')
-        for event in events:
+        self.log_group = log_group
+        self.log_streams = log_streams
+        self.log_results = log_results
+
+        self.errors = []
+        for event in self.log_results:
             self.errors.append(event['message'].strip().split()[-1])
 
     def summary(self, detail=1):
@@ -403,15 +426,29 @@ class StatusLog:
 
 ################################################################
 
-PROOF_STEP_NAMES = ['build', 'property', 'coverage', 'report']
+# A proof is entry-date-time
+# A step is build, property, coverage, report
+# A proof-step is entry-data-time-step
+
+STEPS = ['build', 'property', 'coverage', 'report']
+
+def make_proof_step(proof, step):
+    return  proof + '-' + step
+def make_proof(proof_step):
+    return '-'.join(proof_step.split('-')[:-1])
+def make_step(proof_step):
+    return proof_step.split('-')[-1]
 
 class ProofStepBatchLog:
     def __init__(self, log_groups, proof_step, log_group, log_stream):
         self.proof_step = proof_step
         self.log_group = log_group
         self.log_stream = log_stream
-        self.json = log_groups.read_stream(log_group, log_stream)
-        self.text = [event['message'] for event in self.json['events']]
+        self.json = {}
+        self.text = []
+        if log_group and log_stream: # log_stream might be None
+            self.json = log_groups.read_stream(log_group, log_stream)
+            self.text = [event['message'] for event in self.json['events']]
 
     def summary(self, detail=1):
         result = {
@@ -425,38 +462,42 @@ class ProofStepBatchLog:
             result['json'] = self.json
         return result
 
+class ProofBatchLogs:
+    def __init__(self, log_groups, start, end, proofs):
 
-class ProofBatchLog:
-    def __init__(self, log_groups, start, end, proof):
-
-        make_proof_step = lambda step: proof + '-' + step
-        make_step = lambda proof_step: proof_step.split('-')[-1]
-        self.proof = proof
-        self.proof_steps = [make_proof_step(step) for step in PROOF_STEP_NAMES]
-
-        pattern = ' '.join('?"{}"'.format(step) for step in self.proof_steps)
-        self.log_group, _, log_events = log_groups.matching_streams(
-            log_groups.batch(), pattern, start, end,
-            'Scanning batch logs for {}'.format(proof))
+        proof_steps = [make_proof_step(proof, step)
+                       for proof in proofs
+                       for step in STEPS]
+        pattern = ' '.join('?"{}"'.format(pfstep) for pfstep in proof_steps)
+        matching_streams = log_groups.matching_streams(
+            log_groups.batch(), pattern, start, end, 'Scanning AWS Batch logs')
+        self.log_group, self.log_streams, self.log_results = matching_streams
 
         self.log_stream = {}
-        for proof_step in self.proof_steps:
-            for event in log_events:
-                if proof_step in event['message']:
-                    self.log_stream[make_step(proof_step)] = event['logStreamName']
-                    break
-
         self.log = {}
-        for step in PROOF_STEP_NAMES:
-            self.log[step] = ProofStepBatchLog(
-                log_groups, make_proof_step(step),
-                self.log_group, self.log_stream[step])
+        for event in self.log_results:
+            message = event['message']
+            logstream = event['logStreamName']
+            if message.startswith('Booting with options'):
+                options = json.loads(message[len('Booting with options'):])
+                proof_step = options['jobname']
+                proof = make_proof(proof_step)
+                step = make_step(proof_step)
+                if self.log_stream.get(proof) is None:
+                    self.log_stream[proof] = {}
+                if self.log.get(proof) is None:
+                    self.log[proof] = {}
+                self.log_stream[proof][step] = logstream
+                self.log[proof][step] = ProofStepBatchLog(
+                    log_groups, proof_step, self.log_group, logstream)
 
     def summary(self, detail=1):
         result = {}
-        for step in PROOF_STEP_NAMES:
-            result[self.log[step].proof_step] = self.log[step].summary(detail)
-        return {'BatchLogs': {self.proof: result}}
+        for proof, steplogs in self.log.items():
+            result[proof] = {}
+            for step, log in steplogs.items():
+                result[proof][step] = log.summary(detail)
+        return {'BatchLogs': result}
 
 ################################################################
 
@@ -496,7 +537,7 @@ class ProofBatchStatus:
         result = {}
         for proof in proofs:
             result[proof] = {}
-            for step in PROOF_STEP_NAMES:
+            for step in STEPS:
                 proof_step = '{}-{}'.format(proof, step)
                 result[proof][step] = job_summary(self.jobs.get(proof_step))
         return result
@@ -515,9 +556,11 @@ class ProofBatchStatus:
 def job_summary(job):
     if job is None:
         return None
+    reason = None
+    if job.get('container'):
+        reason = job['container'].get('reason')
     return {'status': job['status'],
-            'reason':
-                job['container'].get('reason') or job['statusReason']}
+            'reason': reason or job['statusReason']}
 
 ################################################################
 
@@ -546,7 +589,10 @@ class ProofResult:
             }
         print(' done')
 
-        self.proof_status = self.log['property'][-2:]
+        self.proof_status = []
+        property_log = self.log['property']
+        if property_log:
+            self.proof_status = property_log[-2:]
 
     def summary(self, detail=1):
         result = {
@@ -612,7 +658,7 @@ def main():
         print(json.dumps(summary, indent=2))
         return
 
-
+    args.proofs = sorted(set(args.proofs))
     prepare = PrepareLog(log_groups, args.proofs, start, end)
     invoke = InvokeLog(log_groups, prepare.commit, start, end)
     proof_results = ProofResults(session, args.proofs)
@@ -623,9 +669,8 @@ def main():
     summary = dict(summary, **proof_results.summary(args.detail))
 
     if args.detail > 3:
-        for proof in args.proofs:
-            log = ProofBatchLog(log_groups, start, end, proof)
-            summary = dict(summary, **log.summary(args.detail))
+        log = ProofBatchLogs(log_groups, start, end, args.proofs)
+        summary = dict(summary, **log.summary(args.detail))
 
     print(json.dumps(summary, indent=2))
 

--- a/ci/snapshot/proof
+++ b/ci/snapshot/proof
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import datetime
+import json
+import logging
+import os
+import re
+import tempfile
+
+import botocore_amazon.monkeypatch
+import boto3
+import botocore
+
+################################################################
+
+def create_parser():
+    arg = argparse.ArgumentParser(
+        description='Scan AWS logs to debug validation errors.')
+
+    arg.add_argument('--profile',
+                     metavar='PROFILE',
+                     required=True,
+                     help="""
+                     The profile for the AWS account with validation errors.
+                     """
+                    )
+    arg.add_argument('--utc',
+                     metavar='UTC',
+                     required=True,
+                     help="""
+                     The approximate time of the error being debugged.
+                     The logs are search for an interval of time including
+                     this time.
+                     This is UTC time given by a valid ISO date string
+                     such as YYYY-MM-DDTHH:MM:SS.
+                     """
+                    )
+    arg.add_argument('--interval',
+                     nargs='+',
+                     metavar='M',
+                     type=int,
+                     default=[20, 60],
+                     help="""
+                     The interval of time about UTC used to search the
+                     logs.  Use --interval A to begin the search A
+                     minutes before UTC. Use
+                     --interval A B to begin the search A minutes
+                     before UTC and end B minutes after UTC
+                     (default: --interval 20 60).
+                     """
+                    )
+
+    arg.add_argument('--proofs',
+                     nargs="+",
+                     help="""
+                     A list of proof names to look up in the logs.
+                     """
+                    )
+
+    arg.add_argument('--detail',
+                     type=int,
+                     default=1,
+                     help="""
+                     Level of detail to print for proofs.
+                     """
+                    )
+
+    arg.add_argument('--verbose',
+                     action='store_true',
+                     help='Verbose output.'
+                    )
+    arg.add_argument('--debug',
+                     action='store_true',
+                     help='Debug output.'
+                    )
+    return arg
+
+################################################################
+
+def time_from_iso(timeiso):
+    if timeiso is None:
+        return None
+    lcltime = datetime.datetime.fromisoformat(timeiso)
+    gmttime = lcltime.replace(tzinfo=datetime.timezone.utc)
+    return int(gmttime.timestamp() * 1000)
+
+def iso_from_time(timems):
+    if timems is None:
+        return None
+    return datetime.datetime.utcfromtimestamp(timems // 1000).isoformat()
+
+def timestamp_interval(utc, interval):
+    if utc == 'now':
+        utctime = int(datetime.datetime.utcnow().timestamp() * 1000)
+    else:
+        utctime = time_from_iso(utc)
+
+    start = interval[0]
+    try:
+        end = interval[1]
+    except IndexError:
+        end = None
+    utcstart = utctime - (start * 60 * 1000)
+    utcend = utctime + (end * 60 * 1000) if end else None
+    return utcstart, utcend
+
+################################################################
+
+class LogGroups:
+    """Manage the log groups for AWS CloudWatch logs."""
+
+    def __init__(self, session):
+        self.client = session.client('logs')
+        # Updating a cloudwatch stack can create a second instance
+        # of a log group with a different hexadecimal suffix.
+        # We restrict attention to the most recently created log group.
+        self.log_groups = sorted(
+            self.client.describe_log_groups()['logGroups'],
+            key=lambda group: group['creationTime'],
+            reverse=True
+        )
+
+    def log_group(self, name):
+        """Log group whose name contains name as a substring."""
+
+        log_groups = [group['logGroupName'] for group in self.log_groups
+                      if name.lower() in group['logGroupName'].lower()]
+        if not log_groups:
+            logging.info("Failed to find log group with name %s", name)
+            return None
+        if len(log_groups) > 1:
+            logging.info("Ignoring log groups with name %s: %s",
+                         name, log_groups)
+        log_name = log_groups[0]
+        logging.info("Found log group with name %s: %s", name, log_name)
+        return log_name
+
+    def webhook(self):
+        """Log group for the webhook lambda."""
+        return self.log_group('github-HandleWebhookLambda')
+
+    def invoke(self):
+        """Log group for the batch invocation lambda."""
+        return self.log_group('github-InvokeBatchLambda')
+
+    def status(self):
+        """Log group for the batch status lambda."""
+        return self.log_group('github-BatchStatusLambda')
+
+    def batch(self):
+        """Log group for AWS Batch."""
+        return self.log_group('/aws/batch/job')
+
+    def prepare(self):
+        """Log group for prepare source."""
+        return self.log_group('prepare')
+
+    def matching_streams(self, log_group, pattern=None,
+                         start_timestamp=None, end_timestamp=None,
+                         text=None):
+        log_group = self.log_group(log_group)
+
+        kwargs = {"logGroupName": log_group,
+                  "startTime": start_timestamp,
+                  "endTime": end_timestamp,
+                  "filterPattern": pattern}
+        paginator = self.client.get_paginator('filter_log_events')
+        page_iterator = paginator.paginate(**kwargs)
+        logging.info("LogGroups filter log events arguments: %s", kwargs)
+
+        log_items = []
+        text = text or 'Reading logs'
+        print(text, end='', flush=True)
+        for page in page_iterator:
+            log_items.extend(page['events'])
+            print(" .", end='', flush=True)
+        print(" done (found {} items)".format(len(log_items)))
+        logging.debug("LogGroups filter log events results: %s", log_items)
+
+        log_streams = list({event['logStreamName'] for event in log_items})
+        logging.info("Returning log group: %s", log_group)
+        logging.info("Returning log streams: %s", log_streams)
+        logging.info("Returning log items: %s", log_items)
+        return log_group, log_streams, log_items
+
+    def read_stream(self, log_group, log_stream):
+        kwargs = {'logGroupName': log_group,
+                  'logStreamName': log_stream,
+                  'startFromHead': True
+                  }
+        events = self.client.get_log_events(**kwargs)
+        return events
+
+################################################################
+
+class PrepareLog:
+    """Manage the AWS CodeBuild log for Prepare-Source invoking CBMC."""
+
+    def __init__(self, log_groups, proofs=None, start=None, end=None):
+        pattern = ""
+        if isinstance(proofs, str):
+            pattern = '"{}"'.format(proofs)
+        if isinstance(proofs, list):
+            pattern = ' '.join(['?"{}"'.format(proof) for proof in proofs])
+
+        log_group, log_streams, _ = log_groups.matching_streams(
+            log_groups.prepare(), pattern, start, end,
+            'Scanning CBMC invocation logs')
+        assert len(log_streams) == 1
+
+        self.log_group = log_group
+        self.log_stream = log_streams[0]
+
+        log_json = log_groups.read_stream(self.log_group, self.log_stream)
+        self.repository = prepare_repository(log_json)
+        self.commit = prepare_commit(log_json)
+        self.tarfile = prepare_tarfile(log_json)
+        self.proofs = prepare_proofs(log_json)
+
+    def summary(self, detail=1):
+        result = {
+            'repository': self.repository,
+            'commit': self.commit,
+            'tarfile': self.tarfile
+        }
+        if detail > 1:
+            result['log_group'] = self.log_group
+            result['log_stream'] = self.log_stream
+            result['proofs'] = self.proofs
+        return {'CBMCInvocation': result}
+
+def prepare_repository(log_json):
+    # Log message format is
+    # INFO: Running "git clone REPO" in "DIR"
+    messages = [event['message'].strip() for event in log_json['events']
+                if event['message'].startswith('INFO: Running "git clone')]
+    assert len(messages) == 1
+    match = re.search('"git clone (.+) .+" in ".+"', messages[0])
+    repo = match.group(1)
+    logging.info('Found repository in prepare log:  %s', repo)
+    return repo
+
+def prepare_commit(log_json):
+    # Log message format is
+    # INFO: Running "git checkout COMMIT" in "DIR"
+    messages = [event['message'].strip() for event in log_json['events']
+                if event['message'].startswith('INFO: Running "git checkout')]
+    assert len(messages) == 1
+    match = re.search('"git checkout (.+)" in ".+"', messages[0])
+    commit = match.group(1)
+    logging.info('Found commit in prepare log:  %s', commit)
+    return commit
+
+def prepare_tarfile(log_json):
+    # Log message format is
+    # INFO: Running "tar fcz TARFILE DIR" in "DIR"
+    messages = [event['message'].strip() for event in log_json['events']
+                if event['message'].startswith('INFO: Running "tar')]
+    assert len(messages) == 1
+    tarfile = messages[0].split()[4]
+    logging.info('Found tarfile in prepare log: %s', tarfile)
+    return tarfile
+
+def prepare_proofs(log_json):
+    # Log message format is
+    # Launching job PROOF:
+    messages = [event['message'].strip() for event in log_json['events']
+                if event['message'].startswith('Launching job')]
+    matches = [re.search('Launching job (.*):', msg) for msg in messages]
+    assert all(matches)
+    proofs = [match.group(1) for match in matches]
+    logging.info("Found proofs in prepare log: %s", proofs)
+    return proofs
+
+################################################################
+
+class InvokeLog:
+    """Manage the logs for the Batch Invocation lambda function"""
+
+    def __init__(self, log_groups, commits=None, start=None, end=None):
+        commit_list = []
+        pattern = ""
+        if isinstance(commits, str):
+            pattern = '"{}"'.format(commits)
+            commit_list = [commits]
+        if isinstance(commits, list):
+            pattern = ' '.join(['?"{}"'.format(commit) for commit in commits])
+            commit_list = commits
+        log_group, log_streams, _ = log_groups.matching_streams(
+            log_groups.invoke(), pattern, start, end,
+            'Scanning CI invocation logs')
+        assert len(log_streams) == 1
+
+        self.log_group = log_group
+        self.log_stream = log_streams[0]
+
+        # Webhook payload is the json blog in the log line following
+        # "GitHub event:"
+        log_json = log_groups.read_stream(self.log_group, self.log_stream)
+        messages = [event['message'] for event in log_json['events']]
+        webhooks = [i+1 for i in range(len(messages))
+                    if messages[i].startswith('GitHub event:')]
+        payloads = [messages[i] for i in webhooks
+                    if any([commit in messages[i] for commit in commit_list])]
+        assert len(payloads) == 1
+        payload = payloads[0]
+        self.webhook = WebHook(payload)
+
+    def summary(self, detail=1):
+        result = {'webhook': self.webhook.summary()}
+        if detail > 1:
+            result['log_group'] = self.log_group
+            result['log_stream'] = self.log_stream
+        return {'ProofInvocation': result}
+
+################################################################
+
+class WebHook:
+    """Parse the webhook payload."""
+
+    def __init__(self, payload):
+
+        webhook = json.loads(payload)
+        headers = {k.lower(): v for k, v in webhook["headers"].items()}
+        body = json.loads(webhook["body"])
+
+        self.event_type = headers.get('x-github-event')
+        # The repository being written to
+        self.base_name = None
+        self.base_branch = None
+        self.base_sha = None
+        # The repository being read from
+        self.head_name = None
+        self.head_branch = None
+        self.head_sha = None
+        # A url describing the event
+        self.url = None
+
+        if self.event_type == 'pull_request':
+            self.base_name = body["pull_request"]["base"]["repo"]["full_name"]
+            self.base_branch = body["pull_request"]["base"]["ref"]
+            self.base_sha = body["pull_request"]["base"]["sha"]
+            self.head_name = body["pull_request"]["head"]["repo"]["full_name"]
+            self.head_branch = body["pull_request"]["head"]["ref"]
+            self.head_sha = body["pull_request"]["head"]["sha"]
+            self.url = body["pull_request"]["html_url"]
+            return
+
+        if self.event_type == 'push':
+            self.base_name = body["repository"]["full_name"]
+            self.base_branch = body["ref"]
+            head_commit = None
+            if body.get('head_commit'):
+                head_commit = body['head_commit']
+            elif body.get('commits'):
+                head_commit = body['commits'][-1]
+            elif body.get('after'):
+                head_commit = {'id': body['after']}
+            if head_commit:
+                self.head_sha = head_commit.get('id')
+                self.url = head_commit.get('url')
+            return
+
+        raise UserWarning('Unknown event type: {}'.format(self.event_type))
+
+    def summary(self, detail=1):
+        result = {
+            'event_type': self.event_type,
+            'base_name': self.base_name,
+            'base_branch': self.base_branch,
+            'base_sha': self.base_sha,
+            'head_name': self.head_name,
+            'head_branch': self.head_branch,
+            'head_sha': self.head_sha,
+            'url': self.url
+        }
+        return result
+
+################################################################
+
+class StatusLog:
+    """Manage the logs for the Batch Status lambda function."""
+
+    def __init__(self, log_groups, start, end=None):
+        self.errors = []
+        self.log_group, self.log_streams, events = log_groups.matching_streams(
+            log_groups.status(), '"Unexpected Verification Result"',
+            start, end, 'Scanning proof status logs')
+        for event in events:
+            self.errors.append(event['message'].strip().split()[-1])
+
+    def summary(self, detail=1):
+        result = self.errors
+        if detail > 1:
+            result = {'log_group': self.log_group,
+                      'log_streams': self.log_streams,
+                      'errors': self.errors}
+        return {'FailedProofs': result}
+
+################################################################
+
+PROOF_STEP_NAMES = ['build', 'property', 'coverage', 'report']
+
+class ProofStepBatchLog:
+    def __init__(self, log_groups, proof_step, log_group, log_stream):
+        self.proof_step = proof_step
+        self.log_group = log_group
+        self.log_stream = log_stream
+        self.json = log_groups.read_stream(log_group, log_stream)
+        self.text = [event['message'] for event in self.json['events']]
+
+    def summary(self, detail=1):
+        result = {
+            'text': self.text
+        }
+        if detail > 2:
+            result['log_group'] = self.log_group
+            result['log_stream'] = self.log_stream
+            result['proof_step'] = self.proof_step
+        if detail > 4:
+            result['json'] = self.json
+        return result
+
+
+class ProofBatchLog:
+    def __init__(self, log_groups, start, end, proof):
+
+        make_proof_step = lambda step: proof + '-' + step
+        make_step = lambda proof_step: proof_step.split('-')[-1]
+        self.proof = proof
+        self.proof_steps = [make_proof_step(step) for step in PROOF_STEP_NAMES]
+
+        pattern = ' '.join('?"{}"'.format(step) for step in self.proof_steps)
+        self.log_group, _, log_events = log_groups.matching_streams(
+            log_groups.batch(), pattern, start, end,
+            'Scanning batch logs for {}'.format(proof))
+
+        self.log_stream = {}
+        for proof_step in self.proof_steps:
+            for event in log_events:
+                if proof_step in event['message']:
+                    self.log_stream[make_step(proof_step)] = event['logStreamName']
+                    break
+
+        self.log = {}
+        for step in PROOF_STEP_NAMES:
+            self.log[step] = ProofStepBatchLog(
+                log_groups, make_proof_step(step),
+                self.log_group, self.log_stream[step])
+
+    def summary(self, detail=1):
+        result = {}
+        for step in PROOF_STEP_NAMES:
+            result[self.log[step].proof_step] = self.log[step].summary(detail)
+        return {'BatchLogs': {self.proof: result}}
+
+################################################################
+
+class ProofBatchStatus:
+    def __init__(self, session, start, end):
+        client = session.client('batch')
+
+        status_list = ['SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING',
+                       'RUNNING', 'SUCCEEDED', 'FAILED']
+
+        paginator = client.get_paginator('list_jobs')
+        kwargs = {'jobQueue': 'CBMCJobQueue'}
+
+        self.jobs = {}
+
+        print('Scanning batch status logs', end='', flush=True)
+        for status in status_list:
+            kwargs['jobStatus'] = status
+            page_iterator = paginator.paginate(**kwargs)
+            for page in page_iterator:
+                print(' .', end='', flush=True)
+                for job in page['jobSummaryList']:
+                    name = job['jobName']
+                    created = job['createdAt']
+                    if start <= created <= end:
+                        self.jobs[name] = job
+        print(' done (found {} items)'.format(len(self.jobs)))
+
+    def failures(self):
+        result = {}
+        for name, job in self.jobs:
+            if job['status'] == 'FAILED':
+                result[name] = job_summary(job)
+        return result
+
+    def report(self, proofs):
+        result = {}
+        for proof in proofs:
+            result[proof] = {}
+            for step in PROOF_STEP_NAMES:
+                proof_step = '{}-{}'.format(proof, step)
+                result[proof][step] = job_summary(self.jobs.get(proof_step))
+        return result
+
+    def summary(self, detail):
+        result = {}
+        for name, job in self.jobs.items():
+            if job['status'] == 'FAILED':
+                step = name.split('-')[-1]
+                proof = name[:-len(step)-1]
+                if result.get(proof) is None:
+                    result[proof] = {}
+                result[proof][step] = job_summary(job)
+        return {'FailedContainers': result}
+
+def job_summary(job):
+    if job is None:
+        return None
+    return {'status': job['status'],
+            'reason':
+                job['container'].get('reason') or job['statusReason']}
+
+################################################################
+
+class ProofResult:
+    def __init__(self, session, proof):
+        self.proof = proof
+        client = session.client('s3')
+
+        self.bucket = cbmc_bucket(client)
+        print('Scanning CBMC proof logs for {} .'.format(proof),
+              end='', flush=True)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            read_file = lambda name: cbmc_file(client, self.bucket,
+                                               proof, name, tmpdir)
+            self.log = {
+                'build': read_file('build.txt'),
+                'property': read_file('cbmc.txt'),
+                'coverage': read_file('coverage.xml'),
+                'report': read_file('report.txt')
+            }
+            self.error = {
+                'build': read_file('build-err.txt'),
+                'property': read_file('cbmc-err.txt'),
+                'coverage': read_file('coverage-err.txt'),
+                'report': read_file('report-err.txt')
+            }
+        print(' done')
+
+        self.proof_status = self.log['property'][-2:]
+
+    def summary(self, detail=1):
+        result = {
+            'proof_status': self.proof_status,
+            'error': self.error
+        }
+        if detail > 1:
+            result['log'] = self.log
+        if detail > 2:
+            result['bucket'] = self.bucket
+        return {self.proof: result}
+
+class ProofResults:
+    def __init__(self, session, proofs):
+        self.results = {}
+        for proof in proofs:
+            self.results[proof] = ProofResult(session, proof)
+
+    def summary(self, detail=1):
+        report = {}
+        for _, result in self.results.items():
+            report = dict(report, **result.summary(detail))
+        return {'CBMCLogs': report}
+
+
+def cbmc_bucket(client):
+    buckets = [bkt['Name'] for bkt in client.list_buckets()['Buckets']]
+    cbmc_buckets = [bkt for bkt in buckets if bkt.endswith(('-cbmc', '-ci'))]
+    cbmc_buckets = [bkt for bkt in cbmc_buckets if bkt]
+    assert len(cbmc_buckets) == 1
+    return cbmc_buckets[0]
+
+def cbmc_file(client, bucket, proof, filename, tmpdir):
+    try:
+        key = '{}/out/{}'.format(proof, filename)
+        path = os.path.join(tmpdir, filename)
+        client.download_file(bucket, key, path)
+        with open(path) as data:
+            return data.read().splitlines()
+    except botocore.exceptions.ClientError:
+        return None
+
+################################################################
+
+def main():
+    args = create_parser().parse_args()
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO)
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    logging.info('Arguments: %s', args)
+
+    session = boto3.session.Session(profile_name=args.profile)
+    log_groups = LogGroups(session)
+    start, end = timestamp_interval(args.utc, args.interval)
+
+    if not args.proofs:
+        summary = {}
+        status = StatusLog(log_groups, start, end)
+        summary = dict(summary, **status.summary(args.detail))
+        proof_batch = ProofBatchStatus(session, start, end)
+        summary = dict(summary, **proof_batch.summary(args.detail))
+        print(json.dumps(summary, indent=2))
+        return
+
+
+    prepare = PrepareLog(log_groups, args.proofs, start, end)
+    invoke = InvokeLog(log_groups, prepare.commit, start, end)
+    proof_results = ProofResults(session, args.proofs)
+
+    summary = {}
+    summary = dict(summary, **invoke.summary(args.detail))
+    summary = dict(summary, **prepare.summary(args.detail))
+    summary = dict(summary, **proof_results.summary(args.detail))
+
+    if args.detail > 3:
+        for proof in args.proofs:
+            log = ProofBatchLog(log_groups, start, end, proof)
+            summary = dict(summary, **log.summary(args.detail))
+
+    print(json.dumps(summary, indent=2))
+
+if __name__ == '__main__':
+    main()
+
+#proof --profile freertos --utc 2019-09-06T05:30:00 --proofs SkipNameField-20190906-053353


### PR DESCRIPTION
An invocation like "proof --profile project --utc 2019-09-06T05:28:20" will print the list of failed proofs and docker containers within a window of the given UTC time.

An invocation like "proof --profile project --utc 2019-09-06T05:28:20 --proofs ProofName-20190906-053325" will print debugging information about the failed proof.  The flag --detail N with N>0 will print additional information (like the batch logs for the failing proof steps).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
