### PR TITLE
Transfer updates from GitFarm to GitHub.

### DIFF
--- a/ci/snapshot/cbmc_ci_github.py
+++ b/ci/snapshot/cbmc_ci_github.py
@@ -210,9 +210,20 @@ def parse_pr(body):
     print("Pull request: {action} {from_repo} -> {to_repo} (draft: {d})".format(
         action=action, from_repo=head_repo_name, to_repo=base_repo_name,
         d=draft))
-    if head_sha is not None and head_repo_name == base_repo_name:
-        print("Ignoring pull request action as base repository matches head")
-        return (None, None, None, None, None)
+
+    # This optimization interacts badly with FreeRTOS branch filtering.
+    #
+    # For historical reasons, FreeRTOS CI restricts attention to a small
+    # collection of branches like master, and ignores all github events
+    # except for a push to or a pull request against one of these
+    # branches.  For special case of a pull request pushed directly to the
+    # repository (and not a fork), the branch filtering skips checking the
+    # push and this optimization skips checking the pull request, meaning
+    # nothing gets checked.
+    #
+    # if head_sha is not None and head_repo_name == base_repo_name:
+    #     print("Ignoring pull request action as base repository matches head")
+    #     return (None, None, None, None, None)
 
     return (base_repo_name, base_repo_id, base_repo_branch, head_sha, draft)
 

--- a/ci/snapshot/prepare_source.py
+++ b/ci/snapshot/prepare_source.py
@@ -220,7 +220,7 @@ def repository_basename(url):
     return repository_name(url).replace('/', '-')
 
 def clone_repository(url, srcdir):
-    cmd = ['git', 'clone', url, srcdir]
+    cmd = ['git', 'clone', '--recursive', url, srcdir]
     run_command(cmd)
 
     # Fetch the pull request data in addtion to the head data that

--- a/ci/snapshot/snapshot-deploy
+++ b/ci/snapshot/snapshot-deploy
@@ -373,9 +373,9 @@ def deploy_prod(stacks, snapshot, secrets, local=False):
 
 def chime_notification(user, snapshot_id, account_id, profile):
     webhook = ("https://hooks.chime.aws/incomingwebhooks/" +
-               "f2aa90e6-f65a-4018-8fcd-bd0c732969c8?token=" +
-               "bFJWODlEUkd8MXxFMmdqV2ZCeUFFZkJLQ2xPUFhqLTlOWk9HR" +
-               "jJvYjd3YzcyWklGRmlPaU5F")
+               "35fb25b1-50ab-4f6f-bcc9-32b213bdfc08?token=" +
+               "RVlJdWFFZ2V8MXxzRjNpM3hEVVRENHB5M3hsalBURk9ubXdXc" +
+               "0prQlFXNi1xZmhKMlc3UEJR")
     headers = {"Content-type": "application/json"}
     data = {"Content":
             "@{} deployed snapshot {} in account {} ({})"


### PR DESCRIPTION
Add three updates to GitHub master branch from GitFarm snapshot branch:
* Remove an optimization with bad interaction with FreeRTOS branch filtering.
* Do recursive clone of git repository to get all submodules of FreeRTOS.
* Move bot update notes to Padstone CI room.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
