### PR TITLE
Add option in snapshot_propose to rename a ProjectName

### DIFF
--- a/ci/snapshot/snapshot-propose
+++ b/ci/snapshot/snapshot-propose
@@ -106,6 +106,12 @@ def create_parser():
                      action='store_true',
                      help='Show the current snapshot in the prod account'
                     )
+
+    arg.add_argument('--current-snapshot-rename-project',
+                     metavar='NAME',
+                     help='Show the current snapshot in the prod account with name NAME'
+                    )
+
     arg.add_argument('--show-last-snapshot',
                      metavar='N',
                      type=int,
@@ -442,6 +448,16 @@ def initial(args, resources):
 def main():
     args = parse_args()
     resources = aws_resources(args)
+
+    if args.current_snapshot_rename_project:
+        current = json.loads(get_current_snapshot_json(**resources[Act.prod]))
+        current["parameters"]["ProjectName"] = args.current_snapshot_rename_project
+        print(json.dumps(current, indent=2))
+        sys.exit()
+
+    if args.show_current_snapshot:
+        print(get_current_snapshot_json(**resources[Act.prod]))
+        sys.exit()
 
     if args.show_current_snapshot:
         print(get_current_snapshot_json(**resources[Act.prod]))

--- a/ci/snapshot/snapshot-update
+++ b/ci/snapshot/snapshot-update
@@ -40,6 +40,9 @@ def create_parser():
                      help='Updating a production account.'
                     )
 
+    arg.add_argument('--current-snapshot-rename-project',
+                     metavar='NAME',
+                     help='Use current snapshot but rename the project id to NAME')
 
     arg.add_argument('--cbmc-sha',
                      metavar='SHA',
@@ -74,7 +77,6 @@ def create_parser():
                      action='store_true',
                      help='Update only the batch packages (but not docker).'
                     )
-
 
     arg.add_argument('--canary',
                      action='store_true',
@@ -124,7 +126,8 @@ def snapshot_propose_args(args):
         '--build-profile': args.build_profile,
         '--cbmc-sha': args.cbmc_sha,
         '--batch-sha': args.batch_sha,
-        '--viewer-sha': args.viewer_sha
+        '--viewer-sha': args.viewer_sha,
+        '--current-snapshot-rename-project': args.current_snapshot_rename_project
     }
     booleans = {
         '--no-cbmc-update': args.no_cbmc_update,


### PR DESCRIPTION

*Description of changes:*

This change adds a new option:

 --current-snapshot-rename-project NAME

to snapshot-propose and snapshot-update.

It is designed to be used when you want to migrate the project name
while leaving the rest of the infrastructure untouched.  This may
be necessary when migrating a prod account.

It was tested by running it on a handful of accounts and checking
the results of shapshot-propose with diff.  The snapshot-update
script is simply a pass-through, and was tested on the ESDK
project to update the name of the project.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
