### PR TITLE
Makefile and Dockerfile fixes and improvements.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,16 +35,12 @@ clean:
 
 veryclean: clean
 
-loginpwd:
-	$(info Generating ECR login password ...)
-	$(eval LOGINPWD = $(shell aws ecr get-login-password --region $(AWSREGION)))
-	$(info ... done.)
-	@test "$(LOGINPWD)" || ( echo "Could not obtain login from AWS ECR"; exit 1 )
-
-login: loginpwd
+login:
 	$(info Logging into ECR ...)
-	@echo $(LOGINPWD) | docker login --username AWS --password-stdin $(AWSID).dkr.ecr.$(AWSREGION).amazonaws.com
-	$(info ... done.)
+	aws ecr get-login-password --region $(AWSREGION) | \
+		docker login --username AWS \
+		--password-stdin \
+		$(AWSID).dkr.ecr.$(AWSREGION).amazonaws.com
 
 .PHONY: default install clean veryclean login loginpwd
 

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,9 @@ login:
 	$(eval LOGINPWD = $(shell aws ecr get-login-password --region $(AWSREGION)))
 	@echo ... done.
 	@test "$(LOGINPWD)" || ( echo "Could not obtain login from AWS ECR"; exit 1 )
-	@echo Attempting login to ECR
+	@echo Logging into ECR ...
 	@echo $(LOGINPWD) | docker login --username AWS --password-stdin $(AWSID).dkr.ecr.$(AWSREGION).amazonaws.com
+	@echo ... done.
 
 .PHONY: default install clean veryclean login
 

--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,14 @@ default:
 	$(MAKE) -C pkg-viewer $@
 	$(MAKE) -C template $@
 
-install:
+install: login
 	$(MAKE) -C docker $@
 	$(MAKE) -C pkg-cbmc $@
 	$(MAKE) -C pkg-batch $@
 	$(MAKE) -C pkg-viewer $@
 	$(MAKE) -C template $@
 
-update:
+update: login
 	$(MAKE) -C docker install
 	$(MAKE) -C pkg-cbmc install
 	$(MAKE) -C pkg-batch install
@@ -36,7 +36,12 @@ clean:
 veryclean: clean
 
 login:
-	aws ecr get-login --no-include-email --region us-east-1
+	@echo Generating ECR login command ...
+	$(eval LOGINCMD = $(shell aws ecr get-login --no-include-email --region $(AWSREGION)))
+	@echo ... done.
+	@test "$(LOGINCMD)" || ( echo "Could not obtain login from AWS ECR"; exit 1 )
+	@echo Executing generated ECR login command
+	$(LOGINCMD)
 
 .PHONY: default install clean veryclean login
 

--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ veryclean: clean
 
 login:
 	@echo Generating ECR login command ...
-	$(eval LOGINCMD = $(shell aws ecr get-login --no-include-email --region $(AWSREGION)))
+	$(eval LOGINPWD = $(shell aws ecr get-login-password --region $(AWSREGION)))
 	@echo ... done.
-	@test "$(LOGINCMD)" || ( echo "Could not obtain login from AWS ECR"; exit 1 )
+	@test "$(LOGINPWD)" || ( echo "Could not obtain login from AWS ECR"; exit 1 )
 	@echo Executing generated ECR login command
-	$(LOGINCMD)
+	@echo $(LOGINPWD) | docker login --username AWS --password-stdin $(AWSID).dkr.ecr.$(AWSREGION).amazonaws.com
 
 .PHONY: default install clean veryclean login
 

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,11 @@ clean:
 veryclean: clean
 
 login:
-	@echo Generating ECR login command ...
+	@echo Generating ECR login password ...
 	$(eval LOGINPWD = $(shell aws ecr get-login-password --region $(AWSREGION)))
 	@echo ... done.
 	@test "$(LOGINPWD)" || ( echo "Could not obtain login from AWS ECR"; exit 1 )
-	@echo Executing generated ECR login command
+	@echo Attempting login to ECR
 	@echo $(LOGINPWD) | docker login --username AWS --password-stdin $(AWSID).dkr.ecr.$(AWSREGION).amazonaws.com
 
 .PHONY: default install clean veryclean login

--- a/Makefile
+++ b/Makefile
@@ -35,14 +35,16 @@ clean:
 
 veryclean: clean
 
-login:
-	@echo Generating ECR login password ...
+loginpwd:
+	$(info Generating ECR login password ...)
 	$(eval LOGINPWD = $(shell aws ecr get-login-password --region $(AWSREGION)))
-	@echo ... done.
+	$(info ... done.)
 	@test "$(LOGINPWD)" || ( echo "Could not obtain login from AWS ECR"; exit 1 )
-	@echo Logging into ECR ...
-	@echo $(LOGINPWD) | docker login --username AWS --password-stdin $(AWSID).dkr.ecr.$(AWSREGION).amazonaws.com
-	@echo ... done.
 
-.PHONY: default install clean veryclean login
+login: loginpwd
+	$(info Logging into ECR ...)
+	@echo $(LOGINPWD) | docker login --username AWS --password-stdin $(AWSID).dkr.ecr.$(AWSREGION).amazonaws.com
+	$(info ... done.)
+
+.PHONY: default install clean veryclean login loginpwd
 

--- a/Makefile
+++ b/Makefile
@@ -42,5 +42,5 @@ login:
 		--password-stdin \
 		$(AWSID).dkr.ecr.$(AWSREGION).amazonaws.com
 
-.PHONY: default install clean veryclean login loginpwd
+.PHONY: default install clean veryclean login
 

--- a/Makefile.template
+++ b/Makefile.template
@@ -22,6 +22,9 @@ export BUILD_TOOLS_AWSID=$(AWSID)
 # Value for MaxVcpus parameter in cloudformation template
 export MAX_VCPUS=16
 
+# AWS Region
+export AWSREGION=us-east-1
+
 # AWS docker repository
-export REPO=$(AWSID).dkr.ecr.us-east-1.amazonaws.com/cbmc
+export REPO=$(AWSID).dkr.ecr.$(AWSREGION).amazonaws.com/cbmc
 

--- a/docker/ubuntu16-gcc/Dockerfile
+++ b/docker/ubuntu16-gcc/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get -y update && \
     apt-get -y install --no-install-recommends \
     bc \
     emacs24-bin-common \
-    gcc \
+    gcc g++-5 gcc-5 \
+    flex bison \
     git \
     libc6-dev-i386 \
     make \
@@ -37,6 +38,11 @@ RUN apt-get -y update && \
     locales \
     locales-all \
     wget
+
+# Python dependencies of awscli
+RUN apt-get -y install --no-install-recommends \
+    libpython-dev libpython3-dev python-dev python3-dev \
+    python-wheel python3-wheel
 
 # install libssl-dev for encryption SDK
 # install cmake, openssl, libssl-dev for MQTT

--- a/docker/ubuntu16-gcc/Dockerfile
+++ b/docker/ubuntu16-gcc/Dockerfile
@@ -39,10 +39,7 @@ RUN apt-get -y update && \
     locales-all \
     wget
 
-# Python dependencies of awscli
-RUN apt-get -y install --no-install-recommends \
-    libpython-dev libpython3-dev python-dev python3-dev \
-    python-wheel python3-wheel
+RUN apt-get -y install --no-install-recommends python-wheel python3-wheel
 
 # install libssl-dev for encryption SDK
 # install cmake, openssl, libssl-dev for MQTT
@@ -58,8 +55,10 @@ RUN pip install --upgrade awscli && \
 RUN apt-get -y --purge remove \
     python-pip \
     python-setuptools \
+    python-wheel \
     python3-pip \
     python3-setuptools \
+    python3-wheel \
     && apt-get -y autoremove && apt-get clean
 
 # Set default encoding to UTF-8. Otherwise files are can be encoded incorrectly leading to CBMC Viewer failures

--- a/docker/ubuntu16-gcc/Dockerfile
+++ b/docker/ubuntu16-gcc/Dockerfile
@@ -8,6 +8,8 @@ FROM ubuntu:16.04
 # Installing default-jdk to get javacc to build cbmc (java component)
 # Installing emacs24-bin-common to get etags (try etags with ctags pkg)
 # Installing bc for Annapurna stage1 Makefile
+# Installing Python pip, setuptools and wheel for awscli & boto3
+#       pip installs of awscli, boto3 and pyyaml build wheel packages
 
 ENV DEBIAN_FRONTEND noninteractive
 ARG UBUNTU_ARCHIVE
@@ -31,15 +33,15 @@ RUN apt-get -y update && \
     python-future \
     python-pip \
     python-setuptools \
+    python-wheel \
     python3 \
     python3-future \
     python3-pip \
     python3-setuptools \
+    python3-wheel \
     locales \
     locales-all \
     wget
-
-RUN apt-get -y install --no-install-recommends python-wheel python3-wheel
 
 # install libssl-dev for encryption SDK
 # install cmake, openssl, libssl-dev for MQTT

--- a/pkg-batch/Makefile
+++ b/pkg-batch/Makefile
@@ -12,7 +12,8 @@ BIN=cbmc-batch
 default:
 	$(RM) -r $(BIN)
 	mkdir $(BIN)
-	cp $(BATCHOBJ) $(BIN)
+	# Copy files to BIN. Depth is 0 because of the '*' in BATCHOBJ variable.
+	find $(BATCHOBJ) -maxdepth 0 -mindepth 0 -type f -not -name '.*' -exec cp -v '{}' $(BIN)/ \;
 	tar fcz $(BIN).tar.gz $(BIN)
 
 install:

--- a/pkg-cbmc/ubuntu14-cbmc/Makefile
+++ b/pkg-cbmc/ubuntu14-cbmc/Makefile
@@ -34,7 +34,13 @@ tarfile:
 		--entrypoint make cbmc:ubuntu14-gcc -C /cbmc cbmc
 
 owner:
-	sudo chown $(shell id -u):$(shell id -g) cbmc.tar.gz
+	$(eval FOWNER = $(shell ls -ld cbmc.tar.gz | awk 'NR==1 {print $$3}' | xargs id -u))
+	$(eval FGROUP = $(shell ls -ld cbmc.tar.gz | awk 'NR==1 {print $$3}' | xargs id -g))
+	$(eval UID = $(shell id -u))
+	$(eval GID = $(shell id -g))
+	[ "$(FOWNER)" = "$(UID)" ] || sudo chown $(UID) cbmc.tar.gz
+	[ "$(FGROUP)" = "$(GID)" ] || chgrp $(GID) cbmc.tar.gz
+	@ls -ld cbmc.tar.gz
 
 install:
 	aws s3 cp cbmc.tar.gz $(PKGBUCKET)/cbmc.tar.gz

--- a/pkg-cbmc/ubuntu16-cbmc/Makefile
+++ b/pkg-cbmc/ubuntu16-cbmc/Makefile
@@ -74,7 +74,7 @@ cbmc-patch:
 	for f in $(PATCHDIR)/*; do git apply $$f; done
 
 cbmc-build:
-	make -C $(CBMCGIT)/cbmc/src minisat2-download
+	make DOWNLOADER='wget' -C $(CBMCGIT)/cbmc/src minisat2-download
 	make -C $(CBMCGIT)/cbmc/src CXX=g++-5 -j8
 
 cbmc-tar:

--- a/pkg-cbmc/ubuntu16-cbmc/Makefile
+++ b/pkg-cbmc/ubuntu16-cbmc/Makefile
@@ -34,7 +34,13 @@ tarfile:
 		--entrypoint make cbmc:ubuntu16-gcc -C /cbmc cbmc
 
 owner:
-	sudo chown $(shell id -u):$(shell id -g) cbmc.tar.gz
+	$(eval FOWNER = $(shell ls -ld cbmc.tar.gz | awk 'NR==1 {print $$3}' | xargs id -u))
+	$(eval FGROUP = $(shell ls -ld cbmc.tar.gz | awk 'NR==1 {print $$3}' | xargs id -g))
+	$(eval UID = $(shell id -u))
+	$(eval GID = $(shell id -g))
+	[ "$(FOWNER)" = "$(UID)" ] || sudo chown $(UID) cbmc.tar.gz
+	[ "$(FGROUP)" = "$(GID)" ] || chgrp $(GID) cbmc.tar.gz
+	@ls -ld cbmc.tar.gz
 
 install:
 	aws s3 cp cbmc.tar.gz $(PKGBUCKET)/cbmc-ubuntu16.tar.gz

--- a/pkg-viewer/Makefile
+++ b/pkg-viewer/Makefile
@@ -11,7 +11,8 @@ BIN=cbmc-viewer
 default:
 	$(RM) -r $(BIN)
 	mkdir $(BIN)
-	cp $(VIEWEROBJ) $(BIN)
+	# Copy files to BIN. Depth is 0 because of the '*' in VIEWEROBJ variable.
+	find $(VIEWEROBJ) -maxdepth 0 -mindepth 0 -type f -not -name '.*' -exec cp -v '{}' $(BIN)/ \;
 	tar fcz $(BIN).tar.gz $(BIN)
 
 install:


### PR DESCRIPTION
Makefile fixes for CBMC (MiniSAT): Use wget as downloader.

Makefile improvements for AWS operations: Execute ECR login
automatically. Set aws region in Makefile.local

Dockerfile fixes: Add awscli dependencies.

Conditionally update owner & group of CBMC package.

Copy only files to create cbmc packages.

Update 'make login' to use get-login-password.

Improve messages in make login.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
