### PR TITLE
Promote from beta to prod must create new snapshot

### DIFF
--- a/ci/snapshot/cbmc_ci_github.py
+++ b/ci/snapshot/cbmc_ci_github.py
@@ -18,7 +18,7 @@ def update_github_status(repo_id, sha, status, ctx, desc, jobname):
     if jobname:
         kwds['target_url'] = (
             "https://s3.console.aws.amazon.com/s3/buckets/{}/{}/out/"
-            .format(os.environ['S3_BKT'], jobname)
+            .format(os.environ['S3_BUCKET_PROOFS'], jobname)
             )
 
     updating = os.environ.get('CBMC_CI_UPDATING_STATUS')
@@ -179,7 +179,7 @@ def get_tar(name, full_name, sha, tmp_dir):
     timer = Timer("Uploading tar containing code for commit to S3")
     s3 = boto3.client('s3')
     s3.upload_file(
-        Bucket=os.environ['S3_BKT'], Key=tar_file, Filename=tar_path)
+        Bucket=os.environ['S3_BUCKET_PROOFS'], Key=tar_file, Filename=tar_path)
     timer.end()
 
     return (tar_path, tar_file)

--- a/ci/snapshot/snapshot-propose
+++ b/ci/snapshot/snapshot-propose
@@ -391,10 +391,7 @@ def propose(args, resources):
 
     shas = update_shas(args, resources[Act.build])
     pkgs = update_pkgs(args, shas, **resources[Act.build])
-    if args.promote_from is not None:
-        current_snapshot_id = get_current_snapshot_id(resources[Act.promote_from]["cf"])
-    else:
-        current_snapshot_id = get_current_snapshot_id(resources[Act.profile]["cf"])
+    current_snapshot_id = get_current_snapshot_id(resources[Act.profile]["cf"])
     build_snapshot = json.loads(get_current_snapshot_json(resources[Act.build]["s3"], resources[Act.build]["bkt"], current_snapshot_id=current_snapshot_id))
     build_snapshot['cbmc'] = pkgs[Pkg.cbmc] or build_snapshot['cbmc']
     build_snapshot['batch'] = pkgs[Pkg.batch] or build_snapshot['batch']
@@ -404,10 +401,6 @@ def propose(args, resources):
     build_snapshot['viewer'] = pkgs[Pkg.viewer] or build_snapshot['viewer']
     del build_snapshot['parameters']['ImageTagSuffix']
     del build_snapshot['parameters']['SnapshotID']
-
-    # If we are promoting a snapshot from one account to another, we need to know the snapshot ID
-    if args.promote_from is not None:
-        build_snapshot['parameters']['SnapshotID'] = current_snapshot_id
 
     logging.info('Proposing snapshot: %s', build_snapshot)
     return build_snapshot
@@ -426,6 +419,18 @@ def initial(args, resources):
     logging.info('Proposing snapshot: %s', prod)
     return prod
 
+def propose_promote_snapshot(resources):
+    snapshot_id_for_source = get_current_snapshot_id(resources[Act.promote_from]["cf"])
+    source_snapshot = get_current_snapshot_json(resources[Act.build]["s3"], resources[Act.build]["bkt"],
+                                                current_snapshot_id=snapshot_id_for_source)
+    snapshot_id_for_target = get_current_snapshot_id(resources[Act.profile]["cf"])
+    target_snapshot = get_current_snapshot_json(resources[Act.build]["s3"], resources[Act.build]["bkt"],
+                                                current_snapshot_id=snapshot_id_for_target)
+    source_snapshot_json = json.loads(source_snapshot)
+    target_snapshot_json = json.loads(target_snapshot)
+    source_snapshot_json["parameters"] = target_snapshot_json["parameters"]
+    del source_snapshot_json["parameters"]["SnapshotID"]
+    return source_snapshot_json
 
 ################################################################
 
@@ -437,6 +442,13 @@ def main():
 
     if args.show_current_snapshot:
         print(get_current_snapshot_json(**resources[Act.profile]))
+        sys.exit()
+
+    # If we are promoting from one account to another, we take the package information from the source account
+    # and the parameters from the target
+    # TODO: These should not all be in the same json. We should not have to build a new snapshot
+    if args.promote_from:
+        print(json.dumps(propose_promote_snapshot(resources), indent=2))
         sys.exit()
 
     if args.show_last_snapshot:

--- a/ci/snapshot/snapshot-update
+++ b/ci/snapshot/snapshot-update
@@ -229,6 +229,20 @@ def update_and_write_snapshot(package_filenames, snapshot):
 ################################################################
 #
 
+def initialize_build_account(build_profile, build_s3_client, build_ecr_client, snapshot):
+    cmd = './snapshot-deploy --profile {} --doit --globals --snapshot snapshot.json'
+    run(cmd.format(build_profile))
+    cmd = './snapshot-deploy --profile {} --build --snapshot snapshot.json'
+    run(cmd.format(build_profile))
+    session = boto3.session.Session(profile_name=build_profile)
+    pipeline_client = session.client("codepipeline")
+    wait_for_pipeline_completion("Build-CBMC-Linux-Pipeline", pipeline_client)
+    wait_for_pipeline_completion("Build-Docker-Pipeline", pipeline_client)
+    wait_for_pipeline_completion("Build-Viewer-Pipeline", pipeline_client)
+    wait_for_pipeline_completion("Build-Batch-Pipeline", pipeline_client)
+    package_filenames = get_package_filenames_from_s3(build_s3_client, build_ecr_client)
+    update_and_write_snapshot(package_filenames, snapshot)
+
 def main():
     args = parse_args()
     profile = args.profile
@@ -244,18 +258,7 @@ def main():
 
     # If we want to set up the shared build account for the first time
     if args.init_build_account:
-        cmd = './snapshot-deploy --profile {} --doit --globals --snapshot snapshot.json'
-        run(cmd.format(build_profile))
-        cmd = './snapshot-deploy --profile {} --build --snapshot snapshot.json'
-        run(cmd.format(build_profile))
-        session = boto3.session.Session(profile_name=build_profile)
-        pipeline_client = session.client("codepipeline")
-        wait_for_pipeline_completion("Build-CBMC-Linux-Pipeline", pipeline_client)
-        wait_for_pipeline_completion("Build-Docker-Pipeline", pipeline_client)
-        wait_for_pipeline_completion("Build-Viewer-Pipeline", pipeline_client)
-        wait_for_pipeline_completion("Build-Batch-Pipeline", pipeline_client)
-        package_filenames = get_package_filenames_from_s3(build_s3_client, build_ecr_client)
-        update_and_write_snapshot(package_filenames, snapshot)
+        initialize_build_account(build_profile, build_s3_client, build_ecr_client, snapshot)
 
     # If we are creating a brand new proof account (with an existing build account), just take all the
     # newest builds from the build account
@@ -270,17 +273,14 @@ def main():
         output = run(cmd)
         write_snapshot_json(output)
 
-    # If we are promoting an account, the snapshot is already built, otherwise build it
-    if args.promote_from:
-        snapshot = snapshott.Snapshot(filename="snapshot.json")
-        sid = snapshot.get_parameter("SnapshotID")
-    else:
-        cmd = './snapshot-create --profile {} --snapshot snapshot.json'
-        output = run(cmd.format(build_profile))
-        sid = parse_snapshot_id(output)
+    # TODO: We shouldn't have to build a new snapshot if we are promoting an account.
+    #  Fix this by separating parameters from snapshot json
+    cmd = './snapshot-create --profile {} --snapshot snapshot.json'
+    output = run(cmd.format(build_profile))
+    sid = parse_snapshot_id(output)
 
-        cmd = './snapshot-deploy --profile {} --snapshotid {} --build'
-        run(cmd.format(build_profile, sid))
+    cmd = './snapshot-deploy --profile {} --snapshotid {} --build'
+    run(cmd.format(build_profile, sid))
 
     if args.proof_account_ids:
         cmd = './snapshot-deploy --profile {} --build-profile {} --snapshotid {} --prod --proof-account-ids {}'


### PR DESCRIPTION
It seems that we have to create a new snapshot for promoting from beta to prod, because snapshot includes account-specific data such as project name. We should separate this into a new JSON so that we get the full benefits of a separate build account, but since this is more involved I will do it in a separate PR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
