### PR TITLE
Move snapshots to proof accounts

### DIFF
--- a/ci/snapshot/README.md
+++ b/ci/snapshot/README.md
@@ -126,15 +126,15 @@ Many different Proof accounts (Beta, Prod, Development) can share the same Tool 
   ProjectName cannot contain a space or other "illegal" characters.
   
 
-* If you are setting up both a completely new shared tool building account and a proof account, and the proof account already has read access in the build account's S3 bucket policy, run the following command:
+* If you are setting up both a completely new shared tool building account and a proof account, run the following command:
 
-        snapshot-update --profile $PROOF-PROFILE --build-profile $BUILD-PROFILE --init-build-account
+        snapshot-update --profile $PROOF-PROFILE --build-profile $BUILD-PROFILE --init-build-account --init-proof-account
 
-* If you are using an existing tool building account, and are setting up a brand new proof account, and the proof account already has read access in the build account's S3 bucket policy, run the following command:
+* If you are using an existing tool building account, and are setting up a brand new proof account, run the following command:
         
         snapshot-update --profile $PROOF-PROFILE --build-profile $BUILD-PROFILE --init-proof-account
         
-* If you would like to propose and create a new, updated snapshot in the build account, and then use that snapshot in the proof account, run the following command:
+* If you would like to propose and create a new, updated snapshot and then use that snapshot in the proof account, run the following command:
 
         snapshot-update --profile $PROOF-PROFILE --build-profile $BUILD-PROFILE
 
@@ -142,9 +142,6 @@ Many different Proof accounts (Beta, Prod, Development) can share the same Tool 
 
 		snapshot-update --profile $PROOF-PROFILE --build-profile $BUILD-PROFILE --promote-from $SOURCE-PROFILE
 
-* If the proof account does not have read access to build account's S3 bucket, add the following flag to any of the previous commands
-
-        --proof-account-ids ACCOUNT_ID
 
 * If you would like the account to post results to github, add the flag
 		--is-prod
@@ -152,13 +149,16 @@ Many different Proof accounts (Beta, Prod, Development) can share the same Tool 
 This will add read access for the proof account to the bucket policy of the shared tool account
 
 
-The intention is that we would first run snapshot-update with --init-build-account flag, which would build all the globals in the shared tools account, create a new snapshot in the build account, and deploy that snapshot in the proof account.
+The intention is that we would first run snapshot-update with --init-build-account and --init-proof-account flags, which would build all the globals in the shared tools account, create a new snapshot in the proof account, and deploy that snapshot in the proof account.
 
-Next, if we needed to initialize a new proof account to share the build account we would use the --init-proof-account flag which would create a new snapshot in the build account and deploy it in the proof account.
+Next, if we needed to initialize a new proof account to share the build account we would use the --init-proof-account flag which would create a new snapshot in the proof account and deploy it in the proof account.
 
-If we want to propose and deploy and updated snapshot for an existing proof account (that has github.yaml deployed), can run snapshot-update without extra flags.
+If we want to propose and deploy and updated snapshot for an existing proof account (which already has its S3 bucket deployed), we can run snapshot-update without any extra flags.
 
-Finally, to promote a snapshot from one account to another, we use --promote-from which takes the source account as an argument. This does not build a new snapshot
+Finally, to promote a snapshot from one account to another, we use --promote-from which takes the source account as an argument. This builds a new snapshot in the target account that has the same packages as the source account
+
+TODO: For now we must manually give permissions for ECR images to be publicly readable from the shared build account. In the future we should automate this,
+and we should give finer grained permissions in case we eventually have images that are not open source
 
 * Configure the web hook on GitHub. The required ID is the id listed by
 

--- a/ci/snapshot/cbmc_ci_github.py
+++ b/ci/snapshot/cbmc_ci_github.py
@@ -18,7 +18,7 @@ def update_github_status(repo_id, sha, status, ctx, desc, jobname):
     if jobname:
         kwds['target_url'] = (
             "https://s3.console.aws.amazon.com/s3/buckets/{}/{}/out/"
-            .format(os.environ['S3_BKT'], jobname)
+            .format(os.environ['S3_BUCKET_PROOFS'], jobname)
             )
 
     updating = os.environ.get('CBMC_CI_UPDATING_STATUS')
@@ -179,7 +179,7 @@ def get_tar(name, full_name, sha, tmp_dir):
     timer = Timer("Uploading tar containing code for commit to S3")
     s3 = boto3.client('s3')
     s3.upload_file(
-        Bucket=os.environ['S3_BKT'], Key=tar_file, Filename=tar_path)
+        Bucket=os.environ['S3_BUCKET_PROOFS'], Key=tar_file, Filename=tar_path)
     timer.end()
 
     return (tar_path, tar_file)

--- a/ci/snapshot/github.yaml
+++ b/ci/snapshot/github.yaml
@@ -4,8 +4,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
-  S3BucketToolsName:
-    Type: String
 
   BuildToolsAccountId:
     Type: String
@@ -23,21 +21,11 @@ Parameters:
     Type: String
     Default: ""
 
-  S3BucketSuffix:
+  S3BucketProofs:
     Type: String
-    Default: "proofs"
-    Description: "S3 bucket will be AccountId-Region-S3BucketSuffix"
+    Description: "Name of S3 bucket for proof account"
 
 Resources:
-
-  S3BucketProofs:
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: !Sub "${AWS::AccountId}-${AWS::Region}-${S3BucketSuffix}"
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
 
   BatchLambdaRole:
     Type: AWS::IAM::Role
@@ -63,21 +51,17 @@ Resources:
               - Action:
                   - s3:GetObject
                 Effect: Allow
-                Resource: !Join ["/", [!Sub "arn:aws:s3:::${S3BucketToolsName}", "*"]]
-              - Action:
-                  - s3:ListBucket
-                Effect: Allow
-                Resource: !Sub "arn:aws:s3:::${S3BucketToolsName}"
+                Resource: !Join ["/", [!Sub "arn:aws:s3:::${S3BucketProofs}", "*"]]
 
               - Action:
                   - s3:GetObject
                   - s3:PutObject
                 Effect: Allow
-                Resource: !Join ["/", [!Sub "${S3BucketProofs.Arn}", "*"]]
+                Resource: !Join ["/", [!Sub "arn:aws:s3:::${S3BucketProofs}", "*"]]
               - Action:
                   - s3:ListBucket
                 Effect: Allow
-                Resource: !Sub "${S3BucketProofs.Arn}"
+                Resource: !Sub "arn:aws:s3:::${S3BucketProofs}"
               - Action:
                   - batch:DescribeJobQueues
                   - batch:DescribeJobDefinitions
@@ -105,7 +89,7 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: !Ref S3BucketToolsName
+        S3Bucket: !Ref S3BucketProofs
         S3Key: !Sub "snapshot/snapshot-${SnapshotID}/lambda.zip"
       Handler: cbmc_ci_start.lambda_handler
       Role: !GetAtt BatchLambdaRole.Arn
@@ -115,14 +99,14 @@ Resources:
       Environment:
         Variables:
           PROJECT_NAME: !Ref ProjectName
-          S3_BKT: !Ref S3BucketToolsName
-          PKG_BKT: !Sub "${S3BucketToolsName}/snapshot/snapshot-${SnapshotID}"
+          S3_BKT: !Ref S3BucketProofs
+          PKG_BKT: !Sub "${S3BucketProofs}/snapshot/snapshot-${SnapshotID}"
 
   BatchStatusLambda:
     Type: AWS::Lambda::Function
     Properties:
       Code:
-        S3Bucket: !Ref S3BucketToolsName
+        S3Bucket: !Ref S3BucketProofs
         S3Key: !Sub "snapshot/snapshot-${SnapshotID}/lambda.zip"
       Handler: cbmc_ci_end.lambda_handler
       Role: !GetAtt BatchLambdaRole.Arn
@@ -131,9 +115,9 @@ Resources:
       Environment:
         Variables:
           PROJECT_NAME: !Ref ProjectName
-          S3_BKT: !Ref S3BucketToolsName
+          S3_BKT: !Ref S3BucketProofs
           S3_BUCKET_PROOFS: !Ref S3BucketProofs
-          PKG_BKT: !Sub "${S3BucketToolsName}/snapshot/snapshot-${SnapshotID}"
+          PKG_BKT: !Sub "${S3BucketProofs}/snapshot/snapshot-${SnapshotID}"
           CBMC_CI_UPDATING_STATUS: True
 
   BatchEventRule:
@@ -393,21 +377,21 @@ Resources:
                   - s3:GetObject
                   - s3:PutObject
                 Effect: Allow
-                Resource: !Join ["/", [!Sub "arn:aws:s3:::${S3BucketToolsName}", "*"]]
+                Resource: !Join ["/", [!Sub "arn:aws:s3:::${S3BucketProofs}", "*"]]
               - Action:
                   - s3:ListBucket
                 Effect: Allow
-                Resource: !Sub "arn:aws:s3:::${S3BucketToolsName}"
+                Resource: !Sub "arn:aws:s3:::${S3BucketProofs}"
 
               - Action:
                   - s3:GetObject
                   - s3:PutObject
                 Effect: Allow
-                Resource: !Join ["/", [!Sub "${S3BucketProofs.Arn}", "*"]]
+                Resource: !Join ["/", [!Sub "arn:aws:s3:::${S3BucketProofs}", "*"]]
               - Action:
                   - s3:ListBucket
                 Effect: Allow
-                Resource: !Sub "${S3BucketProofs.Arn}"
+                Resource: !Sub "arn:aws:s3:::${S3BucketProofs}"
               - Action:
                   - secretsmanager:GetSecretValue
                 Effect: Allow
@@ -442,13 +426,13 @@ Resources:
         EnvironmentVariables:
           - Name: S3_BUCKET_TOOLS
             Type: PLAINTEXT
-            Value: !Ref S3BucketToolsName
+            Value: !Ref S3BucketProofs
           - Name: S3_BUCKET_PROOFS
             Type: PLAINTEXT
             Value: !Ref S3BucketProofs
           - Name: S3_BKT
             Type: PLAINTEXT
-            Value: !Ref S3BucketToolsName
+            Value: !Ref S3BucketProofs
           - Name: S3_PKG_PATH
             Type: PLAINTEXT
             Value: !Sub "snapshot/snapshot-${SnapshotID}"

--- a/ci/snapshot/proofs_s3.yaml
+++ b/ci/snapshot/proofs_s3.yaml
@@ -1,0 +1,29 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  S3BucketSuffix:
+    Type: String
+    Default: "proofs"
+    Description: "S3 bucket will be AccountId-Region-S3BucketSuffix"
+
+Resources:
+
+  S3BucketProofs:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "${AWS::AccountId}-${AWS::Region}-${S3BucketSuffix}"
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+
+
+Outputs:
+
+  S3BucketProofs:
+    Value: !Ref S3BucketProofs
+    Export:
+      Name: S3BucketProofs

--- a/ci/snapshot/snapshot-create
+++ b/ci/snapshot/snapshot-create
@@ -26,6 +26,10 @@ def create_parser():
                      metavar='NAME',
                      help='AWS account profile name'
                     )
+
+    arg.add_argument('--build-profile',
+                     metavar='NAME',
+                     help='AWS account build profile name')
     arg.add_argument('--snapshot',
                      metavar='FILE',
                      default='snapshot.json',
@@ -87,9 +91,12 @@ def extract_templates():
 def main():
     args = create_parser().parse_args()
 
-    session = boto3.session.Session(profile_name=args.profile)
-    stacks = stackst.Stacks(session)
-    s3client = session.client('s3')
+    proof_session = boto3.session.Session(profile_name=args.profile) if args.profile else None
+    build_session = boto3.session.Session(profile_name=args.build_profile)
+    proof_stacks = stackst.Stacks(proof_session) if args.profile else None
+    build_stacks =  stackst.Stacks(build_session)
+    proof_s3client = proof_session.client('s3') if args.profile else None
+    build_s3client = build_session.client('s3')
 
     snapshot = snapshott.Snapshot(filename=args.snapshot)
 
@@ -100,12 +107,15 @@ def main():
     os.mkdir(snapshot_dir)
     os.chdir(snapshot_dir)
 
-    bucket = stacks.get_output('S3BucketName')
-    get_cbmc_tarfile(s3client, bucket, snapshot.get_cbmc())
-    get_batch_tarfile(s3client, bucket, snapshot.get_batch())
-    get_viewer_tarfile(s3client, bucket, snapshot.get_viewer())
-    get_lambda_tarfile(s3client, bucket, snapshot.get_lambda())
-    get_templates_tarfile(s3client, bucket, snapshot.get_templates())
+    build_bucket = build_stacks.get_output("S3BucketName")
+    proof_bucket = proof_stacks.get_output("S3BucketProofs") if args.profile else None
+
+    # Download build files from build account
+    get_cbmc_tarfile(build_s3client, build_bucket, snapshot.get_cbmc())
+    get_batch_tarfile(build_s3client, build_bucket, snapshot.get_batch())
+    get_viewer_tarfile(build_s3client, build_bucket, snapshot.get_viewer())
+    get_lambda_tarfile(build_s3client, build_bucket, snapshot.get_lambda())
+    get_templates_tarfile(build_s3client, build_bucket, snapshot.get_templates())
     extract_templates()
 
     docker = snapshot.get_docker()
@@ -117,11 +127,13 @@ def main():
     print("Writing {}".format(snapshot_file))
     snapshot.write(snapshot_file)
 
-    print("Uploading snapshot to s3://{}/snapshot/{}".
-          format(bucket, snapshot_dir))
-    for filename in os.listdir('.'):
-        s3client.upload_file(Filename=filename, Bucket=bucket,
-                             Key='snapshot/{}/{}'.format(snapshot_dir, filename))
+    # If we have a profile, we upload the snapshot, otherwise we just keep it locally
+    if args.profile:
+        print("Uploading snapshot to s3://{}/snapshot/{}".
+              format(proof_bucket, snapshot_dir))
+        for filename in os.listdir('.'):
+            proof_s3client.upload_file(Filename=filename, Bucket=proof_bucket,
+                                 Key='snapshot/{}/{}'.format(snapshot_dir, filename))
 
 if __name__ == "__main__":
     main()

--- a/ci/snapshot/snapshot-deploy
+++ b/ci/snapshot/snapshot-deploy
@@ -38,6 +38,10 @@ def create_parser():
                      metavar='NAME',
                      help='AWS build tools account profile name')
 
+    arg.add_argument('--deploy-proof-s3-bucket',
+                     action="store_true",
+                     help='Deploy proof account s3 bucket from local snapshot to bootstrap new account')
+
     arg.add_argument('--snapshot',
                      metavar='FILE',
                      help='Snapshot file to deploy from filesystem'
@@ -88,15 +92,11 @@ def get_value(name, stacks, snapshot, secrets):
     except:
         return None
 
-def make_parameters(keys, stacks, snapshot, secrets, s3_bucket_tools_name=None, proof_account_ids=None):
+def make_parameters(keys, stacks, snapshot, secrets, overrides=None):
     parameters = []
     for key in sorted(keys):
-        if key=="S3BucketToolsName" and s3_bucket_tools_name:
-            value = s3_bucket_tools_name
-        elif key == "BuildToolsAccountId" and s3_bucket_tools_name:
-            value = s3_bucket_tools_name.split("-")[0]
-        elif key=="ProofAccountIds" and proof_account_ids:
-            value = ",".join(list(map(lambda p: "arn:aws:iam::{}:root".format(p), proof_account_ids)))
+        if overrides and key in overrides.keys():
+            value = overrides[key]
         else:
             value = get_value(key, stacks, snapshot, secrets)
         if value is not None:
@@ -108,10 +108,12 @@ def print_parameters(parameters):
         print("  {:20}: {}".format(param['ParameterKey'], param['ParameterValue']))
 
 def deploy_stack_local(stack_name, template_name, parameter_keys,
-                       stacks, snapshot, secrets, s3_bucket_name=None):
+                       stacks, snapshot, secrets, s3_bucket_proofs=None, build_account_id=None):
     stack_name = stack_name
     template_body = open(template_name).read()
-    parameters = make_parameters(parameter_keys, stacks, snapshot, secrets, s3_bucket_tools_name=s3_bucket_name)
+    parameters = make_parameters(parameter_keys, stacks, snapshot, secrets,
+                                 overrides={"S3BucketToolsName": s3_bucket_proofs,
+                                            "BuildToolsAccountId": build_account_id})
     capabilities = ['CAPABILITY_NAMED_IAM']
 
     try:
@@ -140,17 +142,18 @@ def deploy_stack_local(stack_name, template_name, parameter_keys,
             raise
 
 def deploy_stack_s3(stack_name, template_name, parameter_keys,
-                    stacks, snapshot, secrets, s3_bucket_tools_name=None, proof_account_ids=None):
-    print("Deplopying stack s3: " + str(s3_bucket_tools_name))
+                    stacks, snapshot, secrets, s3_bucket_proofs=None,
+                    proof_account_ids=None, build_account_id=None):
+    print("Deplopying stack s3: " + str(s3_bucket_proofs))
     stack_name = stack_name
-    s3_bucket_tools_name = s3_bucket_tools_name if s3_bucket_tools_name else stacks.get_output('S3BucketName')
+    s3_bucket_proofs = s3_bucket_proofs if s3_bucket_proofs else stacks.get_output('S3BucketProofs')
 
     template_path = ("https://s3.amazonaws.com/{}/snapshot/snapshot-{}/{}"
-                     .format(s3_bucket_tools_name,
+                     .format(s3_bucket_proofs,
                              snapshot.get_parameter('SnapshotID'),
                              template_name))
     parameters = make_parameters(parameter_keys, stacks, snapshot, secrets,
-                                 s3_bucket_tools_name=s3_bucket_tools_name, proof_account_ids=proof_account_ids)
+                                 overrides={"BuildToolsAccountId": build_account_id})
     capabilities = ['CAPABILITY_NAMED_IAM']
 
     try:
@@ -270,25 +273,25 @@ def deploy_alarms_build(stacks, snapshot, secrets, local=False):
             'BuildCBMCLinuxPipeline'],
            stacks, snapshot, secrets)
 
-def deploy_github(stacks, snapshot, secrets, build_tools_s3_bucket=None, local=False):
+def deploy_github(stacks, snapshot, secrets, build_tools_s3_bucket=None, local=False, build_account_id=None):
     deploy = deploy_stack_local if local else deploy_stack_s3
     deploy('github',
            "github.yaml",
-           ['S3BucketToolsName',
-            'BuildToolsAccountId',
+           ['BuildToolsAccountId',
+            "S3BucketProofs",
             'ProjectName',
             'SnapshotID',
             'GitHubRepository',
             'GitHubBranchName'],
-           stacks, snapshot, secrets, s3_bucket_tools_name=build_tools_s3_bucket)
+           stacks, snapshot, secrets, s3_bucket_proofs=build_tools_s3_bucket, build_account_id= build_account_id)
 
 
-def deploy_cbmc_batch(stacks, snapshot, secrets, build_tools_s3_bucket=None, local=False):
+def deploy_cbmc_batch(stacks, snapshot, secrets, build_tools_s3_bucket=None, local=False, build_account_id=None):
     deploy = deploy_stack_local if local else deploy_stack_s3
     deploy('cbmc-batch',
            "cbmc.yaml",
            ['ImageTagSuffix', 'BuildToolsAccountId'],
-           stacks, snapshot, secrets, s3_bucket_tools_name=build_tools_s3_bucket)
+           stacks, snapshot, secrets, s3_bucket_proofs=build_tools_s3_bucket, build_account_id=build_account_id)
 
 def deploy_alarms_prod(stacks, snapshot, secrets, build_tools_s3_bucket=None, local=False):
     deploy = deploy_stack_local if local else deploy_stack_s3
@@ -297,7 +300,7 @@ def deploy_alarms_prod(stacks, snapshot, secrets, build_tools_s3_bucket=None, lo
            ['ProjectName',
             'SIMAddress',
             'NotificationAddress'],
-           stacks, snapshot, secrets, s3_bucket_tools_name=build_tools_s3_bucket)
+           stacks, snapshot, secrets, s3_bucket_proofs=build_tools_s3_bucket)
 
 def deploy_canary(stacks, snapshot, secrets, build_tools_s3_bucket=None, local=False):
     deploy = deploy_stack_local if local else deploy_stack_s3
@@ -306,14 +309,22 @@ def deploy_canary(stacks, snapshot, secrets, build_tools_s3_bucket=None, local=F
            ['GitHubRepository',
             'GitHubBranchName',
             'GitHubLambdaAPI'],
-           stacks, snapshot, secrets, s3_bucket_tools_name=build_tools_s3_bucket)
+           stacks, snapshot, secrets, s3_bucket_proofs=build_tools_s3_bucket)
 
 def deploy_bucket_policy(stacks, snapshot, secrets, build_tools_s3_bucket=None, proof_account_ids=None, local=False):
     deploy = deploy_stack_local if local else deploy_stack_s3
     deploy("bucket-policy",
            "bucket-policy.yaml",
            ["S3BucketToolsName", "ProofAccountIds"],
-           stacks, snapshot, secrets, s3_bucket_tools_name=build_tools_s3_bucket, proof_account_ids=proof_account_ids)
+           stacks, snapshot, secrets, s3_bucket_proofs=build_tools_s3_bucket, proof_account_ids=proof_account_ids)
+
+def deploy_proof_s3_yaml(stacks, snapshot, secrets, local=None):
+    deploy = deploy_stack_local if local else deploy_stack_s3
+    deploy("proofsS3",
+           "proofs_s3.yaml",
+           [],
+           stacks, snapshot, secrets)
+
 ################################################################
 
 def deploy_build_globals(stacks, snapshot, secrets, doit=None, local=False):
@@ -379,15 +390,16 @@ def deploy_build(stacks, snapshot, secrets, local=False):
         return False
     return True
 
+
 ################################################################
 
-def deploy_prod(stacks, snapshot, secrets, build_tools_s3_bucket, local=False):
-    stks = ['github']
+def deploy_prod(stacks, snapshot, secrets, build_tools_s3_bucket, local=False, build_account_id = None):
+    stks = ['github', 'proofsS3']
     if not stacks.stable_stacks(stks):
         print("Stacks not stable: {}".format(stks))
         return False
-
-    deploy_github(stacks, snapshot, secrets, build_tools_s3_bucket, local)
+    deploy_proof_s3(stacks, snapshot, secrets, local)
+    deploy_github(stacks, snapshot, secrets, build_tools_s3_bucket, local, build_account_id)
     stacks.wait_for_stable_stacks(stks)
     if not stacks.successful_stacks(stks):
         print("Stacks not successful: {}".format(stks))
@@ -398,7 +410,7 @@ def deploy_prod(stacks, snapshot, secrets, build_tools_s3_bucket, local=False):
         print("Stacks not stable: {}".format(stks))
         return False
 
-    deploy_cbmc_batch(stacks, snapshot, secrets, build_tools_s3_bucket, local)
+    deploy_cbmc_batch(stacks, snapshot, secrets, build_tools_s3_bucket, local, build_account_id)
     deploy_alarms_prod(stacks, snapshot, secrets, build_tools_s3_bucket, local)
     deploy_canary(stacks, snapshot, secrets, build_tools_s3_bucket, local)
 
@@ -417,6 +429,19 @@ def deploy_policy(stacks, snapshot, secrets, build_tools_s3_bucket=None, proof_a
         return False
     deploy_bucket_policy(stacks, snapshot, secrets, build_tools_s3_bucket,
                          proof_account_ids, local)
+    stacks.wait_for_stable_stacks(stks)
+    if not stacks.successful_stacks(stks):
+        print("Stacks not successful: {}".format(stks))
+        return False
+    return True
+
+def deploy_proof_s3(stacks, snapshot, secrets, local=False):
+    stks = ['proofsS3']
+    if not stacks.stable_stacks(stks):
+        print("Stacks not stable: {}".format(stks))
+        return False
+
+    deploy_proof_s3_yaml(stacks, snapshot, secrets, local)
     stacks.wait_for_stable_stacks(stks)
     if not stacks.successful_stacks(stks):
         print("Stacks not successful: {}".format(stks))
@@ -468,58 +493,61 @@ def get_allowed_accounts(s3_client, bucket_name):
 
 def main():
     args = create_parser().parse_args()
-
-    session = boto3.session.Session(profile_name=args.profile)
-    stacks = stackst.Stacks(session)
-    snapshot = None
+    proof_session = boto3.session.Session(profile_name=args.profile)
+    proof_stacks = stackst.Stacks(proof_session)
     build_tools_bucket = None
+    proof_bucket = proof_stacks.get_output("S3BucketProofs")
+    build_session = boto3.session.Session(profile_name=args.build_profile) if args.build_profile else None
+    build_account_id = build_session.client("sts").get_caller_identity()["Account"] if args.build_profile else None
+    secrets = secretst.Secrets(proof_session)
+
+    # Deploy S3 bucket from local snapshot to bootstrap new proof account
+    if args.deploy_proof_s3_bucket:
+        snapshot_id = args.snapshotid
+        snapshot_file = "snapshot-{}/snapshot-{}.json".format(snapshot_id,snapshot_id)
+        snapshot = snapshott.Snapshot(filename=snapshot_file)
+        if not deploy_proof_s3(proof_stacks, snapshot, secrets, True):
+            return False
+        return True
 
     # If we are deploying a proof/prod account, we must get the snapshot from the shared build account
     if args.snapshotid and args.prod:
-        build_session = boto3.session.Session(profile_name=args.build_profile)
         build_stacks = stackst.Stacks(build_session)
         snapshot_id = args.snapshotid
         snapshot_file = "snapshot-{}.json".format(snapshot_id)
-        build_tools_bucket = build_stacks.get_output("S3BucketName")
         key = "snapshot/snapshot-{}/{}".format(snapshot_id, snapshot_file)
-        print(build_tools_bucket, key, snapshot_file)
-        build_s3_client = build_session.client('s3')
-        build_s3_client.download_file(Bucket=build_tools_bucket, Key=key, Filename=snapshot_file)
+        proof_s3_client = proof_session.client("s3")
+
+        #Download snapshot from proof account
+        proof_s3_client.download_file(Bucket=proof_bucket, Key=key, Filename=snapshot_file)
         snapshot = snapshott.Snapshot(filename=snapshot_file)
         args.local = False
-        if args.proof_account_ids:
-            build_secrets = secretst.Secrets(build_session)
-            all_allowed_proof_accounts = get_allowed_accounts(build_s3_client, build_tools_bucket)
-            all_allowed_proof_accounts.extend(args.proof_account_ids)
-            if not deploy_policy(build_stacks, snapshot, build_secrets, build_tools_bucket, all_allowed_proof_accounts, args.local):
-                return False
 
     # If we are setting up the build account itself, we only need to reference the build account
     elif args.snapshotid:
         snapshot_id = args.snapshotid
         snapshot_file = "snapshot-{}.json".format(snapshot_id)
-        bucket = stacks.get_output("S3BucketName")
+        bucket = proof_stacks.get_output("S3BucketName")
         key = "snapshot/snapshot-{}/{}".format(snapshot_id, snapshot_file)
         print(bucket, key, snapshot_file)
-        session.client('s3').download_file(Bucket=bucket, Key=key, Filename=snapshot_file)
+        proof_session.client('s3').download_file(Bucket=bucket, Key=key, Filename=snapshot_file)
         snapshot = snapshott.Snapshot(filename=snapshot_file)
         args.local = False
     else:
         snapshot = snapshott.Snapshot(filename=args.snapshot)
         args.local = True
-    secrets = secretst.Secrets(session)
 
     if args.globals:
-        if not deploy_global(stacks, snapshot, secrets, args.doit, args.local):
+        if not deploy_global(proof_stacks, snapshot, secrets, args.doit, args.local):
             return False
     if args.build:
-        if not deploy_build(stacks, snapshot, secrets, args.local):
+        if not deploy_build(proof_stacks, snapshot, secrets, args.local):
             return False
     if args.prod:
-        if not deploy_prod(stacks, snapshot, secrets, build_tools_bucket, args.local):
+        if not deploy_prod(proof_stacks, snapshot, secrets, proof_bucket, args.local, build_account_id):
             return False
 
-        account_id = session.client('sts').get_caller_identity()['Account']
+        account_id = proof_session.client('sts').get_caller_identity()['Account']
         chime_notification(os.environ["USER"], args.snapshotid, account_id, args.profile)
 
     return True

--- a/ci/snapshot/snapshot-propose
+++ b/ci/snapshot/snapshot-propose
@@ -391,11 +391,8 @@ def propose(args, resources):
 
     shas = update_shas(args, resources[Act.build])
     pkgs = update_pkgs(args, shas, **resources[Act.build])
-    if args.promote_from is not None:
-        current_snapshot_id = get_current_snapshot_id(resources[Act.promote_from]["cf"])
-    else:
-        current_snapshot_id = get_current_snapshot_id(resources[Act.profile]["cf"])
-    build_snapshot = json.loads(get_current_snapshot_json(resources[Act.build]["s3"], resources[Act.build]["bkt"], current_snapshot_id=current_snapshot_id))
+    current_snapshot_id = get_current_snapshot_id(resources[Act.profile]["cf"])
+    build_snapshot = json.loads(get_current_snapshot_json(resources[Act.profile]["s3"], resources[Act.profile]["bkt"], current_snapshot_id=current_snapshot_id))
     build_snapshot['cbmc'] = pkgs[Pkg.cbmc] or build_snapshot['cbmc']
     build_snapshot['batch'] = pkgs[Pkg.batch] or build_snapshot['batch']
     build_snapshot['templates'] = pkgs[Pkg.template] or build_snapshot['templates']
@@ -404,10 +401,6 @@ def propose(args, resources):
     build_snapshot['viewer'] = pkgs[Pkg.viewer] or build_snapshot['viewer']
     del build_snapshot['parameters']['ImageTagSuffix']
     del build_snapshot['parameters']['SnapshotID']
-
-    # If we are promoting a snapshot from one account to another, we need to know the snapshot ID
-    if args.promote_from is not None:
-        build_snapshot['parameters']['SnapshotID'] = current_snapshot_id
 
     logging.info('Proposing snapshot: %s', build_snapshot)
     return build_snapshot
@@ -426,6 +419,18 @@ def initial(args, resources):
     logging.info('Proposing snapshot: %s', prod)
     return prod
 
+def propose_promote_snapshot(resources):
+    snapshot_id_for_source = get_current_snapshot_id(resources[Act.promote_from]["cf"])
+    source_snapshot = get_current_snapshot_json(resources[Act.promote_from]["s3"], resources[Act.promote_from]["bkt"],
+                                                current_snapshot_id=snapshot_id_for_source)
+    snapshot_id_for_target = get_current_snapshot_id(resources[Act.profile]["cf"])
+    target_snapshot = get_current_snapshot_json(resources[Act.profile]["s3"], resources[Act.profile]["bkt"],
+                                                current_snapshot_id=snapshot_id_for_target)
+    source_snapshot_json = json.loads(source_snapshot)
+    target_snapshot_json = json.loads(target_snapshot)
+    source_snapshot_json["parameters"] = target_snapshot_json["parameters"]
+    del source_snapshot_json["parameters"]["SnapshotID"]
+    return source_snapshot_json
 
 ################################################################
 
@@ -437,6 +442,12 @@ def main():
 
     if args.show_current_snapshot:
         print(get_current_snapshot_json(**resources[Act.profile]))
+        sys.exit()
+
+    # If we are promoting from one account to another, we take the package information from the source account
+    # and the parameters from the target
+    if args.promote_from:
+        print(json.dumps(propose_promote_snapshot(resources), indent=2))
         sys.exit()
 
     if args.show_last_snapshot:

--- a/ci/snapshot/snapshot-update
+++ b/ci/snapshot/snapshot-update
@@ -124,12 +124,12 @@ def parse_args():
 def run(string):
     print('Running: {}'.format(string))
     result = subprocess.run(string.split(),
-                            check=True, capture_output=True, text=True)
+                            capture_output=True, text=True)
     if result.stdout:
         print(result.stdout)
     if result.stderr:
         print(result.stderr)
-
+    result.check_returncode()
     return result.stdout
 
 def snapshot_propose_args(args):
@@ -229,6 +229,20 @@ def update_and_write_snapshot(package_filenames, snapshot):
 ################################################################
 #
 
+def initialize_build_account(build_profile, build_s3_client, build_ecr_client, snapshot):
+    cmd = './snapshot-deploy --profile {} --doit --globals --snapshot snapshot.json'
+    run(cmd.format(build_profile))
+    cmd = './snapshot-deploy --profile {} --build --snapshot snapshot.json'
+    run(cmd.format(build_profile))
+    session = boto3.session.Session(profile_name=build_profile)
+    pipeline_client = session.client("codepipeline")
+    wait_for_pipeline_completion("Build-CBMC-Linux-Pipeline", pipeline_client)
+    wait_for_pipeline_completion("Build-Docker-Pipeline", pipeline_client)
+    wait_for_pipeline_completion("Build-Viewer-Pipeline", pipeline_client)
+    wait_for_pipeline_completion("Build-Batch-Pipeline", pipeline_client)
+    package_filenames = get_package_filenames_from_s3(build_s3_client, build_ecr_client)
+    update_and_write_snapshot(package_filenames, snapshot)
+
 def main():
     args = parse_args()
     profile = args.profile
@@ -238,30 +252,21 @@ def main():
     build_ecr_client = session.client("ecr")
     snapshot = snapshott.Snapshot(filename="snapshot.json")
 
-    if args.init_build_account and args.init_proof_account:
-        raise Exception("Please choose only one, init-build-account or init-proof-account. If you are initializing"
-                        " both accounts, use --init-build-account")
-
     # If we want to set up the shared build account for the first time
     if args.init_build_account:
-        cmd = './snapshot-deploy --profile {} --doit --globals --snapshot snapshot.json'
-        run(cmd.format(build_profile))
-        cmd = './snapshot-deploy --profile {} --build --snapshot snapshot.json'
-        run(cmd.format(build_profile))
-        session = boto3.session.Session(profile_name=build_profile)
-        pipeline_client = session.client("codepipeline")
-        wait_for_pipeline_completion("Build-CBMC-Linux-Pipeline", pipeline_client)
-        wait_for_pipeline_completion("Build-Docker-Pipeline", pipeline_client)
-        wait_for_pipeline_completion("Build-Viewer-Pipeline", pipeline_client)
-        wait_for_pipeline_completion("Build-Batch-Pipeline", pipeline_client)
+        initialize_build_account(build_profile, build_s3_client, build_ecr_client, snapshot)
+
+    # If we are creating a brand new proof account, we need to bootstrap the process by initializing the S3 bucket
+    if args.init_proof_account:
         package_filenames = get_package_filenames_from_s3(build_s3_client, build_ecr_client)
         update_and_write_snapshot(package_filenames, snapshot)
 
-    # If we are creating a brand new proof account (with an existing build account), just take all the
-    # newest builds from the build account
-    elif args.init_proof_account:
-        package_filenames = get_package_filenames_from_s3(build_s3_client, build_ecr_client)
-        update_and_write_snapshot(package_filenames, snapshot)
+        cmd = './snapshot-create --build-profile {} --snapshot snapshot.json'
+        output = run(cmd.format(build_profile))
+        sid = parse_snapshot_id(output)
+
+        cmd = './snapshot-deploy --profile {} --build-profile {} --deploy-proof-s3-bucket --snapshotid {}'
+        run(cmd.format(profile, build_profile, sid))
 
     # Otherwise we should propose the most recent snapshot. If we are promoting an account, snapshot will include
     # snapshot ID we need to promote
@@ -270,24 +275,12 @@ def main():
         output = run(cmd)
         write_snapshot_json(output)
 
-    # If we are promoting an account, the snapshot is already built, otherwise build it
-    if args.promote_from:
-        snapshot = snapshott.Snapshot(filename="snapshot.json")
-        sid = snapshot.get_parameter("SnapshotID")
-    else:
-        cmd = './snapshot-create --profile {} --snapshot snapshot.json'
-        output = run(cmd.format(build_profile))
-        sid = parse_snapshot_id(output)
+    cmd = './snapshot-create --profile {} --build-profile {} --snapshot snapshot.json'
+    output = run(cmd.format(profile, build_profile))
+    sid = parse_snapshot_id(output)
 
-        cmd = './snapshot-deploy --profile {} --snapshotid {} --build'
-        run(cmd.format(build_profile, sid))
-
-    if args.proof_account_ids:
-        cmd = './snapshot-deploy --profile {} --build-profile {} --snapshotid {} --prod --proof-account-ids {}'
-        run(cmd.format(profile, build_profile, sid, " ".join(args.proof_account_ids)))
-    else:
-        cmd = './snapshot-deploy --profile {} --build-profile {} --snapshotid {} --prod'
-        run(cmd.format(profile, build_profile, sid))
+    cmd = './snapshot-deploy --profile {} --build-profile {} --snapshotid {} --prod'
+    run(cmd.format(profile, build_profile, sid))
 
     cmd = './snapshot-variable --profile {} --operational'
     run(cmd.format(profile))


### PR DESCRIPTION
This patch changes the CI infrastructure to only store snapshots in proof accounts so that they cannot be shared. This has the advantage of keeping a strict separation between shared resources such as the packages themselves and resources related to particular proof accounts. It also has the advantage of removing the need for write access to the shared build account.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
