### PR TITLE
Split project parameters from snapshot information

### DIFF
--- a/ci/snapshot/.gitignore
+++ b/ci/snapshot/.gitignore
@@ -3,4 +3,3 @@ snapshot-*-*
 snapshot.json
 parameters.json
 __pycache__
-project-params-*-*

--- a/ci/snapshot/build-globals.yaml
+++ b/ci/snapshot/build-globals.yaml
@@ -5,13 +5,6 @@ AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
 
-  GitHubRepository:
-    Type: String
-
-  GitHubBranchName:
-    Type: String
-    Default: "master"
-
   BatchRepositoryOwner:
     Type: String
     Default: awslabs
@@ -57,15 +50,6 @@ Outputs:
     Value: !Ref S3Bucket
     Export:
       Name: S3BucketName
-
-  GitHubRepository:
-    Value: !Ref GitHubRepository
-    Export:
-      Name: GitHubRepository
-  GitHubBranchName:
-    Value: !Ref GitHubBranchName
-    Export:
-      Name: GitHubBranchName
 
   BatchRepositoryOwner:
     Value: !Ref BatchRepositoryOwner

--- a/ci/snapshot/cbmc_ci_github.py
+++ b/ci/snapshot/cbmc_ci_github.py
@@ -18,7 +18,7 @@ def update_github_status(repo_id, sha, status, ctx, desc, jobname):
     if jobname:
         kwds['target_url'] = (
             "https://s3.console.aws.amazon.com/s3/buckets/{}/{}/out/"
-            .format(os.environ['S3_BKT'], jobname)
+            .format(os.environ['S3_BUCKET_PROOFS'], jobname)
             )
 
     updating = os.environ.get('CBMC_CI_UPDATING_STATUS')
@@ -179,7 +179,7 @@ def get_tar(name, full_name, sha, tmp_dir):
     timer = Timer("Uploading tar containing code for commit to S3")
     s3 = boto3.client('s3')
     s3.upload_file(
-        Bucket=os.environ['S3_BKT'], Key=tar_file, Filename=tar_path)
+        Bucket=os.environ['S3_BUCKET_PROOFS'], Key=tar_file, Filename=tar_path)
     timer.end()
 
     return (tar_path, tar_file)

--- a/ci/snapshot/github.yaml
+++ b/ci/snapshot/github.yaml
@@ -501,3 +501,13 @@ Outputs:
     Value: !Ref GitHubLambdaAPI
     Export:
       Name: GitHubLambdaAPI
+
+  GitHubRepository:
+    Value: !Ref GitHubRepository
+    Export:
+      Name: GitHubRepository
+
+  GitHubBranchName:
+    Value: !Ref GitHubBranchName
+    Export:
+      Name: GitHubBranchName

--- a/ci/snapshot/project_params.py
+++ b/ci/snapshot/project_params.py
@@ -1,5 +1,13 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+# Example of expected values:
+# {
+#     "ProjectName": "MQTT-Beta2",
+#     "NotificationAddress": "jeid@amazon.com",
+#     "SIMAddress": "jeid@amazon.com",
+#     "GitHubRepository": "eidelmanjonathan/amazon-freertos",
+#     "ViewerRepositoryOwner": "markrtuttle"
+#   }
 
 import json
 

--- a/ci/snapshot/snapshot-deploy
+++ b/ci/snapshot/snapshot-deploy
@@ -82,9 +82,11 @@ def get_value(name, stacks, snapshot, project_params, secrets):
     if name == 'GitHubToken':
         name = 'GitHubCommitStatusPAT'
     try:
+        # User can either provide params in snapshot/project_params
+        # Otherwise we default to what's in the stacks already
         return (snapshot.get_param(name) or
-                stacks.get_output(name) or
                 project_params.project_params.get(name) or
+                stacks.get_output(name) or
                 secrets.get_secret_value(name)[1])
     # pylint: disable=bare-except
     # botocore.errorfactory.ResourceNotFoundException may be thrown here,
@@ -188,6 +190,7 @@ def deploy_stack_s3(stack_name, template_name, parameter_keys,
 
 ################################################################
 
+# TODO: We should not pass project_params when deploying things to shared build account
 def deploy_globals(stacks, snapshot, project_params, secrets, doit=None, local=False):
 
     if not doit:
@@ -210,9 +213,7 @@ def deploy_globals(stacks, snapshot, project_params, secrets, doit=None, local=F
     deploy = deploy_stack_local if local else deploy_stack_s3
     deploy('globals',
            "build-globals.yaml",
-           ["GitHubRepository",
-            "GitHubBranchName",
-            "BatchRepositoryOwner",
+           ["BatchRepositoryOwner",
             "BatchRepositoryName",
             "BatchRepositoryBranchName",
             "ViewerRepositoryOwner",
@@ -223,6 +224,7 @@ def deploy_globals(stacks, snapshot, project_params, secrets, doit=None, local=F
 
     print("Remember to set up the PicaPica replication.")
 
+# TODO: We should not pass project_params when deploying things to shared build account
 def deploy_build_batch(stacks, snapshot, project_params, secrets, local=False):
     deploy = deploy_stack_local if local else deploy_stack_s3
     deploy('build-batch',
@@ -234,6 +236,7 @@ def deploy_build_batch(stacks, snapshot, project_params, secrets, local=False):
             'BatchRepositoryBranchName'],
            stacks, snapshot, project_params, secrets)
 
+# TODO: We should not pass project_params when deploying things to shared build account
 def deploy_build_viewer(stacks, snapshot, project_params, secrets, local=False):
     deploy = deploy_stack_local if local else deploy_stack_s3
     deploy('build-viewer',
@@ -245,6 +248,7 @@ def deploy_build_viewer(stacks, snapshot, project_params, secrets, local=False):
             'ViewerRepositoryBranchName'],
            stacks, snapshot, project_params, secrets)
 
+# TODO: We should not pass project_params when deploying things to shared build account
 def deploy_build_docker(stacks, snapshot, project_params, secrets, local=False):
     deploy = deploy_stack_local if local else deploy_stack_s3
     deploy('build-docker',
@@ -256,6 +260,7 @@ def deploy_build_docker(stacks, snapshot, project_params, secrets, local=False):
             'BatchRepositoryBranchName'],
            stacks, snapshot, project_params, secrets)
 
+# TODO: We should not pass project_params when deploying things to shared build account
 def deploy_build_cbmc_linux(stacks, snapshot, project_params, secrets, local=False):
     deploy = deploy_stack_local if local else deploy_stack_s3
     deploy('build-cbmc-linux',
@@ -265,6 +270,7 @@ def deploy_build_cbmc_linux(stacks, snapshot, project_params, secrets, local=Fal
             'CBMCBranchName'],
            stacks, snapshot, project_params, secrets)
 
+# TODO: We should not pass project_params when deploying things to shared build account
 def deploy_alarms_build(stacks, snapshot, project_params, secrets, local=False):
     deploy = deploy_stack_local if local else deploy_stack_s3
     deploy('alarms-build',
@@ -528,7 +534,7 @@ def main():
             return False
 
         account_id = session.client('sts').get_caller_identity()['Account']
-        # chime_notification(os.environ["USER"], args.snapshotid, account_id, args.profile)
+        chime_notification(os.environ["USER"], args.snapshotid, account_id, args.profile)
 
     return True
 


### PR DESCRIPTION
This fixes the bug where when we promote from one account to another, we copy over the project specific parameters like project name. Now these are fed through a separate JSON and are no longer stored in the shared build tools S3 bucket

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
