### PR TITLE
Updated prepare_source to use merge.

### DIFF
--- a/ci/snapshot/prepare_source.py
+++ b/ci/snapshot/prepare_source.py
@@ -262,11 +262,11 @@ def clone_repository(url, srcdir):
     cmd = ['git', 'fetch', 'origin']
     run_command(cmd, srcdir)
 
-def checkout_repository(sha=None, branch=None, srcdir=None):
+def merge_repository(sha=None, branch=None, srcdir=None):
     checkout = sha or branch
     if checkout is None:
         return
-    cmd = ['git', 'checkout', checkout]
+    cmd = ['git', 'merge', '--no-edit', checkout]
     run_command(cmd, srcdir)
 
 ################################################################
@@ -401,7 +401,7 @@ def source_prepare():
         cbmc_ci_github.update_status("pending", "Proof jobs starting", None, "Status pending", arg.id, arg.sha, False)
         base_name = repository_basename(arg.repository)
         clone_repository(arg.repository, base_name)
-        checkout_repository(arg.sha, arg.branch, base_name)
+        merge_repository(arg.sha, arg.branch, base_name)
         generate_cbmc_makefiles(PROOF_MARKERS, base_name)
         generate_tarfile(arg.tarfile_name, base_name)
         upload_tarfile_to_s3(arg.tarfile_name, arg.bucket_proofs, arg.tarfile_path)


### PR DESCRIPTION
*Issue #, if available:*. This uses merge rather than checkout for combining a PR with the master branch.  If unable to automatically merge, it will error out, but often git is able to merge when a checkout fails.

*Description of changes:*. Just a few lines, changing the checkout to a merge.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
