### PR TITLE
Added log entries for early termination for cbmc_ci_start

### DIFF
--- a/ci/snapshot/cbmc_ci_start.py
+++ b/ci/snapshot/cbmc_ci_start.py
@@ -87,6 +87,7 @@ def lambda_handler(event, context):
         # do nothing in case this was a push deleting a branch
         if sha is None:
             print("Ignoring event: " + json.dumps(event))
+            logger.summary(clog_writert.SUCCEEDED, event, {'result': 'Ignoring event with empty SHA'})
             return 0
 
         to_check = [
@@ -99,8 +100,9 @@ def lambda_handler(event, context):
         branch_tail = branch.split('/')[-1]
 
         if (name == "aws/amazon-freertos" and branch_tail not in to_check):
-            print("Ignoring event on repository {} and branch {}: {}".
-                  format(name, branch, json.dumps(event)))
+            result = "Ignoring event on repository {} and branch {}: {}".format(name, branch, json.dumps(event))
+            print(result)
+            logger.summary(clog_writert.SUCCEEDED, event, {'result': result})
             return 0
 
         child_correlation_list = logger.create_child_correlation_list()


### PR DESCRIPTION
*Issue #, if available:*
This addresses a situation where proofs.py does not report a complete process tree because cbmc_ci_start has an early return.


*Description of changes:*
Added logging statements associated with early returns.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
