### PR TITLE
Specify BuildToolsAccountId in Makefiles

### DIFF
--- a/Makefile.template
+++ b/Makefile.template
@@ -14,10 +14,13 @@ export BATCHDIR = ~/cbmc-batch
 export VIEWERDIR = ~/CBMC-coverage
 
 # AWS account id
-export AWSID=723634282280
+export AWSID=999999999999
 
 # Build Tools accout id for cloudformation template
 export BUILD_TOOLS_AWSID=$(AWSID)
+
+# Value for MaxVcpus parameter in cloudformation template
+export MAX_VCPUS=16
 
 # AWS docker repository
 export REPO=$(AWSID).dkr.ecr.us-east-1.amazonaws.com/cbmc

--- a/Makefile.template
+++ b/Makefile.template
@@ -16,6 +16,9 @@ export VIEWERDIR = ~/CBMC-coverage
 # AWS account id
 export AWSID=723634282280
 
+# Build Tools accout id for cloudformation template
+export BUILD_TOOLS_AWSID=$(AWSID)
+
 # AWS docker repository
 export REPO=$(AWSID).dkr.ecr.us-east-1.amazonaws.com/cbmc
 

--- a/template/Makefile
+++ b/template/Makefile
@@ -11,14 +11,14 @@ install:
 		--stack-name cbmc \
 		--template-body file://cbmc.yaml \
 		--capabilities CAPABILITY_IAM \
-		--parameters ParameterKey=BuildToolsAccountId,ParameterValue=$(BUILD_TOOLS_AWSID)
+		--parameters ParameterKey=BuildToolsAccountId,ParameterValue=$(BUILD_TOOLS_AWSID) ParameterKey=MaxVcpus,ParameterValue=$(MAX_VCPUS)
 
 update:
 	aws cloudformation update-stack \
 		--stack-name cbmc \
 		--template-body file://cbmc.yaml \
 		--capabilities CAPABILITY_IAM \
-		--parameters ParameterKey=BuildToolsAccountId,ParameterValue=$(BUILD_TOOLS_AWSID)
+		--parameters ParameterKey=BuildToolsAccountId,UsePreviousValue=true ParameterKey=MaxVcpus,UsePreviousValue=true
 
 clean:
 	$(RM) *~

--- a/template/Makefile
+++ b/template/Makefile
@@ -10,13 +10,15 @@ install:
 	aws cloudformation create-stack \
 		--stack-name cbmc \
 		--template-body file://cbmc.yaml \
-		--capabilities CAPABILITY_IAM
+		--capabilities CAPABILITY_IAM \
+		--parameters ParameterKey=BuildToolsAccountId,ParameterValue=$(BUILD_TOOLS_AWSID)
 
 update:
 	aws cloudformation update-stack \
 		--stack-name cbmc \
 		--template-body file://cbmc.yaml \
-		--capabilities CAPABILITY_IAM
+		--capabilities CAPABILITY_IAM \
+		--parameters ParameterKey=BuildToolsAccountId,ParameterValue=$(BUILD_TOOLS_AWSID)
 
 clean:
 	$(RM) *~


### PR DESCRIPTION
The CloudFormation template `cbmc.yaml` now needs BuildToolsAccountId specified. Add that to make files. Fixes #40 .


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
