### PR TITLE
Should not trigger builds every time

### DIFF
--- a/ci/snapshot/deployment_tools/account_orchestration/AccountOrchestrator.py
+++ b/ci/snapshot/deployment_tools/account_orchestration/AccountOrchestrator.py
@@ -234,3 +234,12 @@ class AccountOrchestrator:
                             BUILD_TOOLS_CLOUDFORMATION_DATA.keys())
         all_pipelines = reduce(lambda l1, l2: l1 + l2, all_pipelines)
         self.build_tools.trigger_and_wait_for_pipelines(all_pipelines)
+
+    def wait_for_build_pipelines(self):
+        """
+        Waits for all pipelines to complete
+        """
+        all_pipelines = map(lambda k: BUILD_TOOLS_CLOUDFORMATION_DATA[k][PIPELINES_KEY],
+                            BUILD_TOOLS_CLOUDFORMATION_DATA.keys())
+        all_pipelines = reduce(lambda l1, l2: l1 + l2, all_pipelines)
+        self.build_tools.wait_for_pipelines(all_pipelines)

--- a/ci/snapshot/deployment_tools/account_orchestration/AwsAccount.py
+++ b/ci/snapshot/deployment_tools/account_orchestration/AwsAccount.py
@@ -174,7 +174,7 @@ class AwsAccount:
             if PIPELINES_KEY in stacks_to_deploy[key].keys():
                 pipelines.extend(stacks_to_deploy[key][PIPELINES_KEY])
         self.stacks.wait_for_stable_stacks(stack_names)
-        self._wait_for_pipelines(pipelines)
+        self.wait_for_pipelines(pipelines)
 
 
     def get_update_github_status(self):
@@ -246,13 +246,13 @@ class AwsAccount:
         for pipeline in pipelines:
             self.pipeline_manager.trigger_pipeline_async(pipeline)
 
-    def _wait_for_pipelines(self, pipelines):
+    def wait_for_pipelines(self, pipelines):
         for pipeline in pipelines:
             self.pipeline_manager.wait_for_pipeline_completion(pipeline)
 
     def trigger_and_wait_for_pipelines(self, pipelines):
         self._trigger_pipelines(pipelines)
-        self._wait_for_pipelines(pipelines)
+        self.wait_for_pipelines(pipelines)
 
     def _get_s3_url_for_template(self, template_name, parameter_overrides=None):
         snapshot_id = self.snapshot_id if self.snapshot_id else self.parameter_manager.get_value(ParameterManager.SNAPSHOT_ID_KEY, parameter_overrides=parameter_overrides)

--- a/ci/snapshot/tools_deploy.py
+++ b/ci/snapshot/tools_deploy.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
 
     snapshot_to_deploy = None
     if args.generate_snapshot:
-        account_orchestrator.trigger_and_wait_for_build_pipelines()
+        account_orchestrator.wait_for_build_pipelines()
         snapshot_to_deploy = account_orchestrator\
             .generate_new_tool_account_snapshot()
         print("Generated snapshot: {}".format(snapshot_to_deploy))
@@ -77,4 +77,5 @@ if __name__ == '__main__':
         account_orchestrator.deploy_globals_stack()
         account_orchestrator.deploy_build_tools()
         account_orchestrator.deploy_build_alarms()
+        account_orchestrator.wait_for_build_pipelines()
 


### PR DESCRIPTION
Currently we are triggering the build pipelines when we should only be waiting for them to complete


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
