### PR TITLE
Handle PR numbers as well as commit hashes

### DIFF
--- a/ci/snapshot/cbmc_ci_github.py
+++ b/ci/snapshot/cbmc_ci_github.py
@@ -21,11 +21,13 @@ def update_github_status(repo_id, sha, status, ctx, desc, jobname, post_url = Fa
 
     updating = os.environ.get('CBMC_CI_UPDATING_STATUS')
     queue_url = os.environ.get("GITHUB_QUEUE_URL")
+    pr = sha.replace("origin/pr/", "") if "origin/pr/" in sha else None
     if updating and updating.strip().lower() == 'true':
         update_github_msg = {
             "repo_id": repo_id,
             "oath": get_github_personal_access_token(),
             "commit": sha,
+            "pr": pr,
             "status": status,
             "context": "CBMC Batch: " + ctx,
             "description": desc,

--- a/ci/snapshot/github_worker_lambda.py
+++ b/ci/snapshot/github_worker_lambda.py
@@ -56,8 +56,10 @@ def lambda_handler(event, request):
                 print("We are running out API calls, going to sleep without pushing to GitHub")
                 return
             cloudfront_url = github_msg["cloudfront_url"] if "cloudfront_url" in github_msg else None
-            g.update_status(status=github_msg["status"], proof_name=github_msg["context"], commit_sha=github_msg["commit"],
-                            cloudfront_url=cloudfront_url, description=github_msg["description"])
+            commit_sha = github_msg["commit"] if "commit" in github_msg else None
+            pull_request = github_msg["pr"] if "pr" in github_msg else None
+            g.update_status(status=github_msg["status"], proof_name=github_msg["context"], commit_sha=commit_sha,
+                            pull_request=pull_request, cloudfront_url=cloudfront_url, description=github_msg["description"])
             sqs.delete_message(m)
 
 

--- a/ci/snapshot/update_github.py
+++ b/ci/snapshot/update_github.py
@@ -22,14 +22,21 @@ class GithubUpdater:
         print(f"time_to_reset {self.time_to_reset}")
         print(f"total seconds: {self.seconds_to_reset}")
 
-    def update_status(self, status=GIT_SUCCESS, proof_name=None, commit_sha=None, cloudfront_url=None, description=None):
+    def update_status(self, status=GIT_SUCCESS, proof_name=None, commit_sha=None, cloudfront_url=None,
+                      description=None, pull_request=None):
+
         kwds = {'state': status,
                 'context': proof_name,
                 'description': description}
         if cloudfront_url is not None:
             kwds["target_url"] = cloudfront_url
         print(f"Updating github status with the following parameters:\n{json.dumps(kwds, indent=2)}")
+        if commit_sha is None and pull_request is None:
+            raise Exception(f"Invalid github update request for proof {proof_name}."
+                            f" Must provide either commit sha or pull request info")
         start = time.time()
+        if pull_request is not None:
+            commit_sha = self.repo.get_pull(int(pull_request)).head.sha
         self.repo.get_commit(sha=commit_sha).create_status(**kwds)
         end = time.time()
         print(f"Status update took {end - start} seconds")


### PR DESCRIPTION
When we use the retry mechanism, we get PR numbers instead of commit hashes. We need to be able to handle this when sending messages to github worker

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
