### PR TITLE
max vcpus of compute environment is parametrized

### DIFF
--- a/ci/snapshot/deployment_tools/account_orchestration/stacks_data.py
+++ b/ci/snapshot/deployment_tools/account_orchestration/stacks_data.py
@@ -86,7 +86,8 @@ PROOF_ACCOUNT_BATCH_CLOUDFORMATION_DATA = {
     "cbmc-batch": {
         TEMPLATE_NAME_KEY: "cbmc.yaml",
         PARAMETER_KEYS_KEY: ['BuildToolsAccountId',
-                             'ImageTagSuffix']
+                             'ImageTagSuffix',
+                             "MaxVcpus"]
     },
     "alarms-prod": {
         TEMPLATE_NAME_KEY: "alarms-prod.yaml",

--- a/template/cbmc.yaml
+++ b/template/cbmc.yaml
@@ -15,6 +15,9 @@ Parameters:
     Type: String
     Description: "Build tools account ID"
 
+  MaxVcpus:
+    Type: String
+    Description: "Max vCPUs"
 Resources:
 
   VPC:
@@ -180,7 +183,7 @@ Resources:
       Priority: 1
       ComputeEnvironmentOrder:
       - Order: 1
-        ComputeEnvironment: !Ref CBMCComputeEnvironmentWithTemplate4
+        ComputeEnvironment: !Ref CBMCComputeEnvironmentWithTemplate5
 
   # Rename compute environment and launch template by incrementing the last number if you change either one.
   ComputeEnvironmentLaunchTemplate3:
@@ -196,16 +199,16 @@ Resources:
                 VolumeType: io1
       LaunchTemplateName: ComputeEnvironmentLaunchTemplate3
 
-  CBMCComputeEnvironmentWithTemplate4:
+  CBMCComputeEnvironmentWithTemplate5:
     Type: AWS::Batch::ComputeEnvironment
     Properties:
-      ComputeEnvironmentName: CBMCComputeEnvironmentWithTemplate4
+      ComputeEnvironmentName: CBMCComputeEnvironmentWithTemplate5
       Type: MANAGED
       ComputeResources:
         Type: EC2
         MinvCpus: 0
         DesiredvCpus: 8
-        MaxvCpus: 160
+        MaxvCpus: !Ref MaxVcpus
         InstanceTypes:
         - r4.2xlarge
         Subnets:
@@ -222,7 +225,7 @@ Resources:
 
 Outputs:
   ComputeEnvironmentArn:
-    Value: !Ref CBMCComputeEnvironmentWithTemplate4
+    Value: !Ref CBMCComputeEnvironmentWithTemplate5
   JobQueueArn:
     Value: !Ref JobQueue
   Ubuntu14GccJobDefinitionArn:


### PR DESCRIPTION
This patch parametrizes the max vcpus value of the compute environment allowing us to give different values on different accounts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
