### PR TITLE
Fixed deployment so we can select which docker image version we want …

### DIFF
--- a/ci/snapshot/deployment_tools/snapshot_managers/SnapshotManager.py
+++ b/ci/snapshot/deployment_tools/snapshot_managers/SnapshotManager.py
@@ -31,6 +31,8 @@ CBMC_VIEWER_CONST = "cbmc-viewer"
 CBMC_VIEWER_TAR = "cbmc-viewer.tar.gz"
 SNAPSHOT_TMP_FILENAME = "snapshot_tmp.json"
 
+IMAGE_TAG_SUFFIX = "ImageTagSuffix"
+
 class SnapshotManager:
     """
     This is the class that manages any kind of snapshot of an account and handles saving those snapshots
@@ -181,8 +183,8 @@ class SnapshotManager:
                 self._extract_package(downloaded_pkg)
             self._rename_package_tar(package, downloaded_pkg)
 
-        if overrides and "ImageTagSuffix" in overrides:
-            package_filenames["ImageTagSuffix"] = overrides["ImageTagSuffix"]
+        if overrides and IMAGE_TAG_SUFFIX in overrides:
+            package_filenames[IMAGE_TAG_SUFFIX] = overrides[IMAGE_TAG_SUFFIX]
 
         self._generate_snapshot_file(package_filenames)
         self._upload_template_package()

--- a/ci/snapshot/deployment_tools/snapshot_managers/SnapshotManager.py
+++ b/ci/snapshot/deployment_tools/snapshot_managers/SnapshotManager.py
@@ -143,10 +143,6 @@ class SnapshotManager:
         with open(image_file, "w") as f:
             f.write(json.dumps(package_filenames))
 
-    def _get_most_recent_cbmc_image(self):
-        image_name = self.ecr.list_images(repositoryName=CBMC_REPO_NAME)[IMAGE_IDS_KEY][0][IMAGE_TAG_KEY]
-        return remove_substring(image_name, UBUNTU_IMAGE_PREFIX)
-
     def _rename_package_tar(self, package_name, package_filename):
         current_dir = os.getcwd()
         os.chdir(self.local_snapshot_dir)
@@ -185,9 +181,8 @@ class SnapshotManager:
                 self._extract_package(downloaded_pkg)
             self._rename_package_tar(package, downloaded_pkg)
 
-        #TODO In the future we may want this to be more general
-        image_tag_suffix = self._get_most_recent_cbmc_image()
-        package_filenames["ImageTagSuffix"] = "-{}".format(image_tag_suffix)
+        if overrides and "ImageTagSuffix" in overrides:
+            package_filenames["ImageTagSuffix"] = overrides["ImageTagSuffix"]
 
         self._generate_snapshot_file(package_filenames)
         self._upload_template_package()

--- a/ci/snapshot/padstone_deploy.py
+++ b/ci/snapshot/padstone_deploy.py
@@ -99,7 +99,6 @@ if __name__ == '__main__':
         if args.package_overrides:
             package_overrides = get_package_overrides(args.package_overrides)
         add_proof_account_to_bucket_policy_only_once(account_orchestrator)
-        package_overrides["ImageTagSuffix"] = account_orchestrator.proof_account.parameter_manager.get_value("ImageTagSuffix")
         snapshot_to_deploy = account_orchestrator\
             .generate_new_proof_account_snapshot(overrides=package_overrides)
 

--- a/ci/snapshot/padstone_deploy.py
+++ b/ci/snapshot/padstone_deploy.py
@@ -95,10 +95,11 @@ if __name__ == '__main__':
         raise Exception("Should not provide a snapshot ID if you are trying to generate a new snapshot")
     snapshot_to_deploy = None
     if args.generate_snapshot:
-        package_overrides = None
+        package_overrides = {}
         if args.package_overrides:
             package_overrides = get_package_overrides(args.package_overrides)
         add_proof_account_to_bucket_policy_only_once(account_orchestrator)
+        package_overrides["ImageTagSuffix"] = account_orchestrator.proof_account.parameter_manager.get_value("ImageTagSuffix")
         snapshot_to_deploy = account_orchestrator\
             .generate_new_proof_account_snapshot(overrides=package_overrides)
 

--- a/template/cbmc.yaml
+++ b/template/cbmc.yaml
@@ -8,7 +8,6 @@ Description: AWS CloudFormation Template for CBMC
 Parameters:
   ImageTagSuffix:
     Type: String
-    Default: ""
     Description: "A suffix for the container image tag indicating an image version"
 
   BuildToolsAccountId:


### PR DESCRIPTION
Currently we are allowing the deployment script to choose the docker image we run the proofs in. I think this process is buggy and either way we should allow users to specify the Docker image they would like to use in the project preferences


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
