### PR TITLE
Github worker no longer throws exception when it fails to post to github

### DIFF
--- a/ci/snapshot/deployment_tools/account_orchestration/stacks_data.py
+++ b/ci/snapshot/deployment_tools/account_orchestration/stacks_data.py
@@ -121,7 +121,7 @@ PROOF_ACCOUNT_GITHUB_CLOUDFORMATION_DATA = {
 GITHUB_WORKER_DATA = {
     "github-worker": {
         TEMPLATE_NAME_KEY: "github_worker.yaml",
-        PARAMETER_KEYS_KEY: ["SnapshotID", "S3BucketToolsName"]
+        PARAMETER_KEYS_KEY: ["SnapshotID", "S3BucketToolsName", 'NotificationAddress', 'SIMAddress', "ProjectName"]
     }
 }
 

--- a/ci/snapshot/github_worker.yaml
+++ b/ci/snapshot/github_worker.yaml
@@ -118,7 +118,7 @@ Resources:
       EvaluationPeriods: 1
       MetricName: ApproximateNumberOfMessagesVisible
       Namespace: "AWS/SQS"
-      Period: 86400
+      Period: 60
       Statistic: Maximum
       Threshold: 1.0
       TreatMissingData: breaching

--- a/ci/snapshot/github_worker.yaml
+++ b/ci/snapshot/github_worker.yaml
@@ -116,7 +116,7 @@ Resources:
         - !Ref DlqAlarmTopic
       ComparisonOperator: LessThanThreshold
       EvaluationPeriods: 1
-      MetricName: ApproximateNumberOfMessagesVisible
+      MetricName: NumberOfMessagesSent
       Namespace: "AWS/SQS"
       Period: 60
       Statistic: Maximum

--- a/ci/snapshot/github_worker.yaml
+++ b/ci/snapshot/github_worker.yaml
@@ -4,6 +4,12 @@ Parameters:
     Type: String
   S3BucketToolsName:
     Type: String
+
+  NotificationAddress:
+    Type: String
+  SIMAddress:
+    Type: String
+
 Resources:
 
   GitHubCallQueue:
@@ -96,6 +102,188 @@ Resources:
                   - sqs:*
                 Effect: Allow
                 Resource: "*"
+
+
+######## Alarms ##############
+  DlqAlarm:
+    DependsOn: SESLambda
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !Ref DlqAlarmTopic
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 1
+      MetricName: Attempts
+      Namespace: !Ref ProjectName
+      Period: 86400
+      Statistic: Minimum
+      Threshold: 1.0
+      TreatMissingData: breaching
+
+  DlqAlarmTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: !Sub "DlqAlarmTopic Failure"
+      TopicName: !Sub "DlqAlarmTopic-failure"
+
+  DlqEventTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: "*"
+            Action: sns:Publish
+            Resource: !Ref DlqAlarmTopic
+            Condition:
+              ArnEquals:
+                "aws:SourceArn": !GetAtt DlqAlarm.Arn
+      Topics:
+        - !Ref DlqAlarmTopic
+
+  SnsDlqSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !GetAtt SESLambda.Arn
+      Protocol: lambda
+      TopicArn: !Ref SnsCanaryTopic
+
+################################################################
+# SES: Simple Email Service
+################################################################
+
+# TODO: The SESLambdaRole and SESLambda are identical in
+# alarms-build and alarms-prod and could be included from
+# a shared template stored on S3.
+
+################################################################
+# SES lambda
+
+  SESLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub "ses-lambda-policy-${AWS::Region}"
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Effect: Allow
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
+              - Action:
+                  - ses:SendEmail
+                Effect: Allow
+                Resource: "*"
+
+  SESLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Handler: index.lambda_handler
+      Role: !GetAtt SESLambdaRole.Arn
+      Runtime: python2.7
+      Timeout: 60
+      MemorySize: 128
+      Code:
+        ZipFile: !Sub |
+          import boto3
+          import json
+          import os
+          import traceback
+
+          SENDER = '${NotificationAddress}'
+          TO = '${SIMAddress}'
+
+          def lambda_handler(event, context):
+            ses = boto3.client('ses', region_name=os.environ['AWS_REGION'])
+            try:
+              subject = event['Records'][0]['Sns']['Subject']
+              if not subject:
+                subject = 'Pipeline error in ${AWS::AccountId}'
+              message = json.loads(event['Records'][0]['Sns']['Message'])
+              body = json.dumps(message, sort_keys=True, indent=2)
+              ses.send_email(
+                Source=SENDER,
+                Destination={'ToAddresses': [TO]},
+                Message={
+                  'Subject': {'Data': '${ProjectName} ' + subject},
+                  'Body': {
+                    'Text': {'Data': body},
+                    'Html': {
+                      'Data': '<html><head></head><body>{}</body></html>'.format(
+                        body.replace('\n', '<br>'))
+                    }
+                  }
+                })
+
+            except Exception as e:
+              traceback.print_exc()
+              print 'Error: ' + str(e)
+              print 'Event: ' + str(event)
+              ses.send_email(
+                Source=SENDER,
+                Destination={'ToAddresses': [TO]},
+                Message={
+                  'Subject': {'Data': 'SES Lambda ${AWS::AccountId} failed'},
+                  'Body': {
+                    'Text': {'Data': str(e)},
+
+
+                    'Html': {
+                      'Data': '<html><head></head><body>{}</body></html>'.format(e)
+                    }
+                  }
+                })
+
+################################################################
+# Lambda
+################################################################
+
+################################################################
+# Lambda permissions
+
+  SnsLambdaSESLambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      Principal: sns.amazonaws.com
+      SourceArn: !Ref SnsLambdaTopic
+      FunctionName: !GetAtt SESLambda.Arn
+
+  SnsVerificationSESLambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      Principal: sns.amazonaws.com
+      SourceArn: !Ref SnsVerificationTopic
+      FunctionName: !GetAtt SESLambda.Arn
+
+  SnsCodeBuildSESLambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      Principal: sns.amazonaws.com
+      SourceArn: !Ref SnsCodeBuildTopic
+      FunctionName: !GetAtt SESLambda.Arn
+
+  SnsCanarySESLambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      Principal: sns.amazonaws.com
+      SourceArn: !Ref SnsCanaryTopic
+      FunctionName: !GetAtt SESLambda.Arn
+
 Outputs:
   GithubQueueUrl:
     Value: !Ref  GitHubCallQueue

--- a/ci/snapshot/github_worker.yaml
+++ b/ci/snapshot/github_worker.yaml
@@ -124,7 +124,7 @@ Resources:
       TreatMissingData: notBreaching
       Dimensions:
         - Name: QueueName
-          Value: !GetAtt GitHubDeadLetterQueue.Arn
+          Value: !GetAtt GitHubDeadLetterQueue.QueueName
 
   DlqAlarmTopic:
     Type: AWS::SNS::Topic

--- a/ci/snapshot/github_worker.yaml
+++ b/ci/snapshot/github_worker.yaml
@@ -121,7 +121,7 @@ Resources:
       Period: 60
       Statistic: Maximum
       Threshold: 1.0
-      TreatMissingData: breaching
+      TreatMissingData: notBreaching
       Dimensions:
         - Name: QueueName
           Value: !GetAtt GitHubDeadLetterQueue.Arn

--- a/ci/snapshot/github_worker.yaml
+++ b/ci/snapshot/github_worker.yaml
@@ -116,12 +116,15 @@ Resources:
         - !Ref DlqAlarmTopic
       ComparisonOperator: LessThanThreshold
       EvaluationPeriods: 1
-      MetricName: Attempts
-      Namespace: !Ref ProjectName
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: "AWS/SQS"
       Period: 86400
-      Statistic: Minimum
+      Statistic: Maximum
       Threshold: 1.0
       TreatMissingData: breaching
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt GitHubDeadLetterQueue.Arn
 
   DlqAlarmTopic:
     Type: AWS::SNS::Topic

--- a/ci/snapshot/github_worker.yaml
+++ b/ci/snapshot/github_worker.yaml
@@ -255,36 +255,13 @@ Resources:
 ################################################################
 # Lambda permissions
 
-  SnsLambdaSESLambdaInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      Principal: sns.amazonaws.com
-      SourceArn: !Ref SnsLambdaTopic
-      FunctionName: !GetAtt SESLambda.Arn
-
-  SnsVerificationSESLambdaInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      Principal: sns.amazonaws.com
-      SourceArn: !Ref SnsVerificationTopic
-      FunctionName: !GetAtt SESLambda.Arn
-
-  SnsCodeBuildSESLambdaInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      Principal: sns.amazonaws.com
-      SourceArn: !Ref SnsCodeBuildTopic
-      FunctionName: !GetAtt SESLambda.Arn
 
   SnsCanarySESLambdaInvokePermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
       Principal: sns.amazonaws.com
-      SourceArn: !Ref SnsCanaryTopic
+      SourceArn: !Ref DlqAlarmTopic
       FunctionName: !GetAtt SESLambda.Arn
 
 Outputs:

--- a/ci/snapshot/github_worker.yaml
+++ b/ci/snapshot/github_worker.yaml
@@ -211,36 +211,35 @@ Resources:
           TO = '${SIMAddress}'
 
           def lambda_handler(event, context):
-            ses = boto3.client('ses', region_name=os.environ['AWS_REGION'])
-            try:
-              subject = event['Records'][0]['Sns']['Subject']
-              if not subject:
-                subject = 'Pipeline error in ${AWS::AccountId}'
-              message = json.loads(event['Records'][0]['Sns']['Message'])
-              body = json.dumps(message, sort_keys=True, indent=2)
-              ses.send_email(
-                Source=SENDER,
-                Destination={'ToAddresses': [TO]},
-                Message={
-                  'Subject': {'Data': '${ProjectName} ' + subject},
-                  'Body': {
-                    'Text': {'Data': body}
-                  }
-                })
-
-            except Exception as e:
-              traceback.print_exc()
-              print 'Error: ' + str(e)
-              print 'Event: ' + str(event)
-              ses.send_email(
-                Source=SENDER,
-                Destination={'ToAddresses': [TO]},
-                Message={
-                  'Subject': {'Data': 'SES Lambda ${AWS::AccountId} failed'},
-                  'Body': {
-                    'Text': {'Data': str(e)}
-                  }
-                })
+              ses = boto3.client('ses', region_name=os.environ['AWS_REGION'])
+              try:
+                  subject = event['Records'][0]['Sns']['Subject']
+                  if not subject:
+                      subject = 'Pipeline error in ${AWS::AccountId}'
+                  message = json.loads(event['Records'][0]['Sns']['Message'])
+                  body = json.dumps(message, sort_keys=True, indent=2)
+                  ses.send_email(
+                      Source=SENDER,
+                      Destination={'ToAddresses': [TO]},
+                      Message={
+                          'Subject': {'Data': '${ProjectName} ' + subject},
+                          'Body': {
+                              'Text': {'Data': body}
+                          }
+                      })
+              except Exception as e:
+                  traceback.print_exc()
+                  print(f'Error: {str(e)}')
+                  print(f'Event: {str(event)}')
+                  ses.send_email(
+                      Source=SENDER,
+                      Destination={'ToAddresses': [TO]},
+                      Message={
+                          'Subject': {'Data': 'SES Lambda ${AWS::AccountId} failed'},
+                          'Body': {
+                              'Text': {'Data': str(e)}
+                          }
+                      })
 
 ################################################################
 # Lambda

--- a/ci/snapshot/github_worker.yaml
+++ b/ci/snapshot/github_worker.yaml
@@ -197,7 +197,7 @@ Resources:
     Properties:
       Handler: index.lambda_handler
       Role: !GetAtt SESLambdaRole.Arn
-      Runtime: python3.8
+      Runtime: python3.7
       Timeout: 60
       MemorySize: 128
       Code:

--- a/ci/snapshot/github_worker.yaml
+++ b/ci/snapshot/github_worker.yaml
@@ -150,7 +150,7 @@ Resources:
     Properties:
       Endpoint: !GetAtt SESLambda.Arn
       Protocol: lambda
-      TopicArn: !Ref SnsCanaryTopic
+      TopicArn: !Ref DlqAlarmTopic
 
 ################################################################
 # SES: Simple Email Service

--- a/ci/snapshot/github_worker.yaml
+++ b/ci/snapshot/github_worker.yaml
@@ -114,13 +114,13 @@ Resources:
     Properties:
       AlarmActions:
         - !Ref DlqAlarmTopic
-      ComparisonOperator: LessThanThreshold
+      ComparisonOperator: GreaterThanThreshold
       EvaluationPeriods: 1
       MetricName: NumberOfMessagesSent
       Namespace: "AWS/SQS"
       Period: 60
       Statistic: Maximum
-      Threshold: 1.0
+      Threshold: 0.0
       TreatMissingData: notBreaching
       Dimensions:
         - Name: QueueName

--- a/ci/snapshot/github_worker.yaml
+++ b/ci/snapshot/github_worker.yaml
@@ -10,6 +10,9 @@ Parameters:
   SIMAddress:
     Type: String
 
+  ProjectName:
+    Type: String
+
 Resources:
 
   GitHubCallQueue:

--- a/ci/snapshot/github_worker.yaml
+++ b/ci/snapshot/github_worker.yaml
@@ -197,7 +197,7 @@ Resources:
     Properties:
       Handler: index.lambda_handler
       Role: !GetAtt SESLambdaRole.Arn
-      Runtime: python2.7
+      Runtime: python3.8
       Timeout: 60
       MemorySize: 128
       Code:
@@ -224,11 +224,7 @@ Resources:
                 Message={
                   'Subject': {'Data': '${ProjectName} ' + subject},
                   'Body': {
-                    'Text': {'Data': body},
-                    'Html': {
-                      'Data': '<html><head></head><body>{}</body></html>'.format(
-                        body.replace('\n', '<br>'))
-                    }
+                    'Text': {'Data': body}
                   }
                 })
 
@@ -242,12 +238,7 @@ Resources:
                 Message={
                   'Subject': {'Data': 'SES Lambda ${AWS::AccountId} failed'},
                   'Body': {
-                    'Text': {'Data': str(e)},
-
-
-                    'Html': {
-                      'Data': '<html><head></head><body>{}</body></html>'.format(e)
-                    }
+                    'Text': {'Data': str(e)}
                   }
                 })
 

--- a/ci/snapshot/github_worker_lambda.py
+++ b/ci/snapshot/github_worker_lambda.py
@@ -1,9 +1,10 @@
 import os
 import json
 import time
-from math import floor, ceil
-from datetime import datetime
-from time import sleep
+import traceback
+
+
+from github import GithubException
 from update_github import GithubUpdater
 
 import boto3
@@ -58,8 +59,12 @@ def lambda_handler(event, request):
             cloudfront_url = github_msg["cloudfront_url"] if "cloudfront_url" in github_msg else None
             commit_sha = github_msg["commit"] if "commit" in github_msg else None
             pull_request = github_msg["pr"] if "pr" in github_msg else None
-            g.update_status(status=github_msg["status"], proof_name=github_msg["context"], commit_sha=commit_sha,
-                            pull_request=pull_request, cloudfront_url=cloudfront_url, description=github_msg["description"])
+            try:
+                g.update_status(status=github_msg["status"], proof_name=github_msg["context"], commit_sha=commit_sha,
+                                pull_request=pull_request, cloudfront_url=cloudfront_url, description=github_msg["description"])
+            except GithubException as e:
+                print(f"ERROR: Failed to send message: {json.dumps(github_msg, indent=2)}")
+                traceback.print_exc()
             sqs.delete_message(m)
 
 


### PR DESCRIPTION
Github worker no longer throws exception when it fails to post to github, and we now alarm when messages go on the DLQ


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
