### PR TITLE
Send env variable for external solver

### DIFF
--- a/template/cbmc.yaml
+++ b/template/cbmc.yaml
@@ -177,6 +177,9 @@ Resources:
         Image: !Sub ${BuildToolsAccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/cbmc:ubuntu16-gcc${ImageTagSuffix}
         Vcpus: 2
         Memory: 16000
+        Environment:
+          - Name: ExternalSatSolver
+            Value: kissat
       RetryStrategy:
         Attempts: 1
 


### PR DESCRIPTION
Add an environment variable to use kissat as the CBMC external solver if available

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
