### PR TITLE
Pass ImageTagSuffix to CloudFormation template

### DIFF
--- a/template/Makefile
+++ b/template/Makefile
@@ -11,14 +11,20 @@ install:
 		--stack-name cbmc \
 		--template-body file://cbmc.yaml \
 		--capabilities CAPABILITY_IAM \
-		--parameters ParameterKey=BuildToolsAccountId,ParameterValue=$(BUILD_TOOLS_AWSID) ParameterKey=MaxVcpus,ParameterValue=$(MAX_VCPUS)
+		--parameters \
+		ParameterKey=BuildToolsAccountId,ParameterValue=$(BUILD_TOOLS_AWSID) \
+		ParameterKey=MaxVcpus,ParameterValue=$(MAX_VCPUS) \
+		ParameterKey=ImageTagSuffix,ParameterValue=$(IMAGETAGSUFFIX)
 
 update:
 	aws cloudformation update-stack \
 		--stack-name cbmc \
 		--template-body file://cbmc.yaml \
 		--capabilities CAPABILITY_IAM \
-		--parameters ParameterKey=BuildToolsAccountId,UsePreviousValue=true ParameterKey=MaxVcpus,UsePreviousValue=true
+		--parameters \
+		ParameterKey=BuildToolsAccountId,UsePreviousValue=true \
+		ParameterKey=MaxVcpus,UsePreviousValue=true \
+		ParameterKey=ImageTagSuffix,UsePreviousValue=true
 
 clean:
 	$(RM) *~


### PR DESCRIPTION
ImageTagSuffix is also needed by the CloudFormation template. The IMAGETAGSUFFIX variable in Makefiles seems to be for this purpose, based on what I see in the docker Makefiles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
